### PR TITLE
fix: increase synthesis timeout from 120s to 300s

### DIFF
--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -234,7 +234,7 @@ export interface SynthesisOptions {
 }
 
 export function synthesizeWithClaude(prompt: string, options: SynthesisOptions = {}): Promise<{ success: boolean; stdout: string; stderr: string; error?: string }> {
-  const timeoutMs = options.timeoutMs ?? 120_000;
+  const timeoutMs = options.timeoutMs ?? 300_000;
 
   return new Promise((resolve) => {
     const args = ["-p", "--output-format", "text"];


### PR DESCRIPTION
## Summary

- `synthesizeWithClaude` のデフォルトタイムアウトを120s → 300sに変更
- CLI (`npx`) と UI再合成 (`skill-server`) の両方に適用

## Test plan

- [x] 322テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)