### PR TITLE
Fix tokenize() RangeError on large session corpora

### DIFF
--- a/scripts/__tests__/tokenizer.test.ts
+++ b/scripts/__tests__/tokenizer.test.ts
@@ -155,3 +155,28 @@ describe("tokenize", () => {
     expect(tokens).not.toContain("go");
   });
 });
+
+describe("tokenize - large input regression (Issue #18)", () => {
+  // Real Claude Code sessions can contain `ls -R` / `find` / `tree` dumps
+  // with hundreds of thousands of path segments. `tokens.push(...arr)` on
+  // such an array hits V8's argument count limit and throws
+  // `RangeError: Maximum call stack size exceeded` even though it is not
+  // recursion. See https://github.com/chigichan24/crune/issues/18.
+  it("extractPathTokens does not throw on a huge corpus of file paths", () => {
+    const pathSegments = Array.from(
+      { length: 100_000 },
+      (_, i) => `/dir${i}/file${i}.ts`
+    );
+    const text = pathSegments.join(" ");
+    expect(() => extractPathTokens(text)).not.toThrow();
+  });
+
+  it("tokenize does not throw on a huge corpus of file paths", () => {
+    const pathSegments = Array.from(
+      { length: 100_000 },
+      (_, i) => `/dir${i}/file${i}.ts`
+    );
+    const text = pathSegments.join(" ");
+    expect(() => tokenize(text)).not.toThrow();
+  });
+});

--- a/scripts/knowledge-graph/tokenizer.ts
+++ b/scripts/knowledge-graph/tokenizer.ts
@@ -22,7 +22,8 @@ export function extractPathTokens(text: string): string[] {
       const name = seg.replace(/\.[^.]+$/, ""); // remove extension
       if (name.length > 2) {
         // Avoid `tokens.push(...arr)` — large arrays exceed V8's argument
-        // count limit and throw RangeError. See Issue #18.
+        // count limit and throw RangeError.
+        // See https://github.com/chigichan24/crune/issues/18
         for (const t of splitCamelCase(name)) tokens.push(t);
       }
     }
@@ -44,7 +45,8 @@ export function tokenize(text: string): string[] {
 
   // Extract file path tokens first.
   // Avoid `tokens.push(...arr)` — large arrays exceed V8's argument
-  // count limit and throw RangeError. See Issue #18.
+  // count limit and throw RangeError.
+  // See https://github.com/chigichan24/crune/issues/18
   for (const t of extractPathTokens(text)) tokens.push(t);
 
   // Split on whitespace, punctuation, CJK boundaries

--- a/scripts/knowledge-graph/tokenizer.ts
+++ b/scripts/knowledge-graph/tokenizer.ts
@@ -21,7 +21,9 @@ export function extractPathTokens(text: string): string[] {
     for (const seg of segments) {
       const name = seg.replace(/\.[^.]+$/, ""); // remove extension
       if (name.length > 2) {
-        tokens.push(...splitCamelCase(name));
+        // Avoid `tokens.push(...arr)` — large arrays exceed V8's argument
+        // count limit and throw RangeError. See Issue #18.
+        for (const t of splitCamelCase(name)) tokens.push(t);
       }
     }
   }
@@ -40,8 +42,10 @@ export function isNoiseToken(token: string): boolean {
 export function tokenize(text: string): string[] {
   const tokens: string[] = [];
 
-  // Extract file path tokens first
-  tokens.push(...extractPathTokens(text));
+  // Extract file path tokens first.
+  // Avoid `tokens.push(...arr)` — large arrays exceed V8's argument
+  // count limit and throw RangeError. See Issue #18.
+  for (const t of extractPathTokens(text)) tokens.push(t);
 
   // Split on whitespace, punctuation, CJK boundaries
   const words = text


### PR DESCRIPTION
## Summary
- Replace two `tokens.push(...arr)` spread calls in `scripts/knowledge-graph/tokenizer.ts` with explicit `for...of` push loops (lines 24 and 44 in the original file).
- Add two regression tests (`scripts/__tests__/tokenizer.test.ts`) that drive 100k path segments through the tokenizer.

## Why
`tokens.push(...arr)` passes every array element as an individual function argument. V8 enforces an argument count limit; once a single Claude Code session contains enough path-like text (e.g. `find` / `ls -R` / `tree` dumps), `extractPathTokens` returns an array large enough to blow that limit and `tokenize` throws `RangeError: Maximum call stack size exceeded`. The error message is misleading — it is the argument-count limit, not recursion.

This was reported in #18 against `~/.claude/projects/` containing 1504 sessions, and the suggested fix in that issue is exactly the change here.

## Test plan
- [x] `npm test` — 976 tests pass.
- [x] `npm run lint` — no new errors (pre-existing warnings only, unrelated).
- [x] `npx tsc --noEmit -p tsconfig.app.json` and `tsconfig.node.json` — clean.
- [x] Confirmed the new `tokenize` regression test fails on `main` with `RangeError: Maximum call stack size exceeded`, and passes after the fix.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)