### PR TITLE
Wire skill evaluation into pipeline + UI + soft threshold (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,24 @@ npm run dev:full    # Runs skill-server + Vite dev server
 
 The skill server (`scripts/skill-server.ts`) accepts POST requests at `/api/synthesize` and calls `claude -p` with the enriched prompt including graph context.
 
+### Skill Evaluation (issue #20)
+
+After a candidate is synthesized, `analyze-sessions` evaluates the generated SKILL.md via `scripts/skill-evaluator.ts` and persists the result onto `SkillCandidate.evaluation` (serialized into `overview.json`). Evaluation is gated behind synthesis **success** so heuristic `skillMarkdown` is never scored.
+
+Three layers (`evaluateSkill`):
+1. **Structural validation** --- deterministic zod-backed YAML frontmatter checks (name kebab-case, description length, body present). Always runs locally.
+2. **LLM rubric** --- `claude -p` scores the skill 0-100 across nameQuality / descriptionTriggering / instructionsConcrete / noPreambleNoise (25 each). Runs unless `--skip-eval`.
+3. **Smoke firing** --- stubbed (deferred to a follow-up issue); always reports `skipped: true`.
+
+`overallScore` = 50 for structural pass + scaled rubric (0-50). `toSkillEvaluation()` strips the raw LLM response and intermediate parse before persistence.
+
+Flags (next to the `--synthesize-*` flags, eval defaults **ON**):
+- `--skip-eval` --- Skip the LLM rubric (structural-only).
+- `--eval-model <model>` --- Claude model for rubric scoring (e.g. `haiku`).
+- `--eval-threshold <n>` --- Soft threshold (default 60). When `overallScore < n`, the pipeline runs **exactly one** bounded re-synthesis retry and keeps the higher-scoring attempt. The candidate is never dropped; low scores are flagged in the UI. `--eval-threshold 0` disables retries. The retry decision is the pure function `shouldRetrySynthesis(score, threshold)`.
+
+**UI badge**: When `candidate.evaluation` exists, `KnowledgeNodeDetail` and `TacitKnowledgeView` render a compact評価バッジ --- 構造 OK/NG, スコア NN/100, optional rubric内訳, and 改善ヒント list. Pass/borderline/fail tone uses `--success`/`--warning`/`--danger` (pass ≥70, borderline ≥50, fail otherwise or structural NG).
+
 ## Session Summarization
 
 セッション一覧の `firstUserPrompt` フィールドは、facetsデータが利用可能な場合は `/insights` の `brief_summary`（LLM生成の要約）で置き換えられる。facetsがないセッションは従来通り最初のユーザープロンプトを表示する。
@@ -127,7 +145,8 @@ All domain types are in `src/types/session.ts`. Key types:
 - `SessionDetail`, `ConversationTurn`, `AssistantBlock` --- playback data
 - `KnowledgeGraph`, `TopicNode`, `TopicEdge` --- graph data
 - `ReusabilityScore` --- includes `successRate?` and `helpfulness?` (facets-derived, optional)
-- `SkillCandidate` --- includes `skillMarkdown` (heuristic) and `synthesizedMarkdown` (LLM-synthesized)
+- `SkillCandidate` --- includes `skillMarkdown` (heuristic), `synthesizedMarkdown` (LLM-synthesized), and `evaluation` (`SkillEvaluation`, issue #20)
+- `SkillEvaluation` --- persisted evaluation: `structural`, optional `rubric`, optional `smokeFiring` (stub), `overallScore`
 - `GraphContext`, `ConnectedTopicInfo` --- graph context for synthesis
 - `TacitKnowledge`, `WorkflowPattern` --- extracted insights
 

--- a/scripts/__tests__/analyze-sessions-args.test.ts
+++ b/scripts/__tests__/analyze-sessions-args.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../analyze-sessions.js";
+
+describe("parseArgs (analyze-sessions)", () => {
+  it("defaults eval ON (skipEval false) mirroring synthesize defaults", () => {
+    const args = parseArgs([]);
+    expect(args.skipEval).toBe(false);
+    expect(args.evalModel).toBeUndefined();
+    expect(args.skipSynthesis).toBe(false);
+  });
+
+  it("sets skipEval with --skip-eval", () => {
+    expect(parseArgs(["--skip-eval"]).skipEval).toBe(true);
+  });
+
+  it("sets evalModel with --eval-model", () => {
+    expect(parseArgs(["--eval-model", "haiku"]).evalModel).toBe("haiku");
+  });
+
+  it("keeps eval flags independent from synthesize flags", () => {
+    const args = parseArgs(["--skip-synthesize", "--eval-model", "sonnet"]);
+    expect(args.skipSynthesis).toBe(true);
+    expect(args.skipEval).toBe(false);
+    expect(args.evalModel).toBe("sonnet");
+  });
+});

--- a/scripts/__tests__/analyze-sessions-args.test.ts
+++ b/scripts/__tests__/analyze-sessions-args.test.ts
@@ -17,6 +17,23 @@ describe("parseArgs (analyze-sessions)", () => {
     expect(parseArgs(["--eval-model", "haiku"]).evalModel).toBe("haiku");
   });
 
+  it("defaults evalThreshold to 60", () => {
+    expect(parseArgs([]).evalThreshold).toBe(60);
+  });
+
+  it("sets evalThreshold with --eval-threshold", () => {
+    expect(parseArgs(["--eval-threshold", "75"]).evalThreshold).toBe(75);
+  });
+
+  it("clamps evalThreshold into [0, 100]", () => {
+    expect(parseArgs(["--eval-threshold", "150"]).evalThreshold).toBe(100);
+    expect(parseArgs(["--eval-threshold", "-5"]).evalThreshold).toBe(0);
+  });
+
+  it("falls back to 60 for non-numeric --eval-threshold", () => {
+    expect(parseArgs(["--eval-threshold", "abc"]).evalThreshold).toBe(60);
+  });
+
   it("keeps eval flags independent from synthesize flags", () => {
     const args = parseArgs(["--skip-synthesize", "--eval-model", "sonnet"]);
     expect(args.skipSynthesis).toBe(true);

--- a/scripts/__tests__/skill-evaluator.test.ts
+++ b/scripts/__tests__/skill-evaluator.test.ts
@@ -7,6 +7,7 @@ import {
   evaluateSkill,
   smokeFireTest,
   toSkillEvaluation,
+  shouldRetrySynthesis,
   type EvaluationResult,
 } from "../skill-evaluator.js";
 
@@ -335,6 +336,27 @@ describe("toSkillEvaluation (persistence mapper)", () => {
     expect(out.rubric?.skipped).toBe(true);
     expect(out.rubric?.error).toBe("boom");
     expect("rawResponse" in (out.rubric as object)).toBe(false);
+  });
+});
+
+describe("shouldRetrySynthesis (soft threshold)", () => {
+  it("retries when score is strictly below threshold", () => {
+    expect(shouldRetrySynthesis(59, 60)).toBe(true);
+    expect(shouldRetrySynthesis(0, 60)).toBe(true);
+  });
+
+  it("does not retry when score meets or exceeds threshold", () => {
+    expect(shouldRetrySynthesis(60, 60)).toBe(false);
+    expect(shouldRetrySynthesis(90, 60)).toBe(false);
+  });
+
+  it("treats undefined score as 0 (retry)", () => {
+    expect(shouldRetrySynthesis(undefined, 60)).toBe(true);
+  });
+
+  it("never retries when threshold is 0 (feature off)", () => {
+    expect(shouldRetrySynthesis(0, 0)).toBe(false);
+    expect(shouldRetrySynthesis(undefined, 0)).toBe(false);
   });
 });
 

--- a/scripts/__tests__/skill-evaluator.test.ts
+++ b/scripts/__tests__/skill-evaluator.test.ts
@@ -6,6 +6,8 @@ import {
   buildRubricPrompt,
   evaluateSkill,
   smokeFireTest,
+  toSkillEvaluation,
+  type EvaluationResult,
 } from "../skill-evaluator.js";
 
 const goodSkill = `---
@@ -265,6 +267,74 @@ describe("smokeFireTest", () => {
     const result = await smokeFireTest(goodSkill);
     expect(result.skipped).toBe(true);
     expect(typeof result.message).toBe("string");
+  });
+});
+
+describe("toSkillEvaluation (persistence mapper)", () => {
+  const baseResult: EvaluationResult = {
+    structural: {
+      valid: true,
+      issues: [{ field: "body", message: "example" }],
+      parsed: { name: "x", description: "y" },
+    },
+    rubric: {
+      ok: true,
+      score: 80,
+      breakdown: {
+        nameQuality: 20,
+        descriptionTriggering: 20,
+        instructionsConcrete: 20,
+        noPreambleNoise: 20,
+      },
+      hints: ["tighten description"],
+      rawResponse: "SECRET RAW LLM OUTPUT",
+    },
+    smokeFiring: { skipped: true, message: "stub" },
+    overallScore: 90,
+  };
+
+  it("strips rawResponse from the rubric", () => {
+    const out = toSkillEvaluation(baseResult);
+    expect(out.rubric).toBeDefined();
+    expect("rawResponse" in (out.rubric as object)).toBe(false);
+  });
+
+  it("preserves structural, rubric scores, smokeFiring, and overallScore", () => {
+    const out = toSkillEvaluation(baseResult);
+    expect(out.structural.valid).toBe(true);
+    expect(out.structural.issues).toEqual([{ field: "body", message: "example" }]);
+    expect(out.rubric?.score).toBe(80);
+    expect(out.rubric?.breakdown?.nameQuality).toBe(20);
+    expect(out.rubric?.hints).toEqual(["tighten description"]);
+    expect(out.smokeFiring?.skipped).toBe(true);
+    expect(out.overallScore).toBe(90);
+  });
+
+  it("does not leak the structural parsed field (not part of the persistable shape)", () => {
+    const out = toSkillEvaluation(baseResult);
+    expect("parsed" in (out.structural as object)).toBe(false);
+  });
+
+  it("omits rubric when absent", () => {
+    const out = toSkillEvaluation({
+      structural: { valid: false, issues: [] },
+      smokeFiring: { skipped: true },
+      overallScore: 0,
+    });
+    expect(out.rubric).toBeUndefined();
+  });
+
+  it("carries rubric error/skipped flags without rawResponse", () => {
+    const out = toSkillEvaluation({
+      structural: { valid: true, issues: [] },
+      rubric: { ok: false, skipped: true, error: "boom", rawResponse: "noise" },
+      smokeFiring: { skipped: true },
+      overallScore: 50,
+    });
+    expect(out.rubric?.ok).toBe(false);
+    expect(out.rubric?.skipped).toBe(true);
+    expect(out.rubric?.error).toBe("boom");
+    expect("rawResponse" in (out.rubric as object)).toBe(false);
   });
 });
 

--- a/scripts/__tests__/skill-evaluator.test.ts
+++ b/scripts/__tests__/skill-evaluator.test.ts
@@ -379,4 +379,15 @@ describe("evaluateSkill (orchestrator)", () => {
     expect(result.overallScore).toBe(50);
     expect(result.rubric?.skipped).toBe(true);
   });
+
+  it("does not invoke the rubric LLM when structural validation fails (even without skipRubric)", async () => {
+    const broken = `# no frontmatter at all`;
+    // No skipRubric: structural failure alone must short-circuit the claude -p
+    // call. If the LLM were invoked this would spawn a process / hang in CI.
+    const result = await evaluateSkill(broken);
+    expect(result.structural.valid).toBe(false);
+    expect(result.overallScore).toBe(0);
+    expect(result.rubric?.skipped).toBe(true);
+    expect(result.rubric?.ok).toBe(false);
+  });
 });

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -595,7 +595,8 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
 
             // Soft threshold: a SINGLE bounded re-synthesis retry when the
             // overall score is below threshold. The candidate is never dropped
-            // — we keep whichever attempt scored higher and let the UI flag
+            // — we keep the retry only when it strictly beats the original
+            // (a tie keeps the original, for determinism) and let the UI flag
             // low scores. The retry only makes sense when the rubric is available;
             // with --skip-eval the structural-only score can't improve, so skip it.
             const threshold = synthesisConfig.evalThreshold ?? 60;
@@ -607,7 +608,7 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
               if (retry.success) {
                 const retryMarkdown = stripSynthesisPreamble(retry.stdout);
                 const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
-                if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
+                if ((retryEval.overallScore ?? 0) > (evalResult.overallScore ?? 0)) {
                   original.synthesizedMarkdown = retryMarkdown;
                   evalResult = retryEval;
                 }

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -578,36 +578,53 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
           // so heuristic markdown (skillMarkdown) is never scored. Structural
           // validation ALWAYS runs locally; --skip-eval only turns off the LLM
           // rubric (structural-only mode).
-          const evalOpts: EvaluatorOptions = {
-            skipRubric: synthesisConfig.skipEval,
-          };
-          if (synthesisConfig.evalModel) {
-            evalOpts.model = synthesisConfig.evalModel;
-          }
-          let evalResult = await evaluateSkill(original.synthesizedMarkdown, evalOpts);
+          //
+          // Evaluation is best-effort and MUST NOT destroy the primary synthesis
+          // output: any throw here is caught, logged, and leaves
+          // `synthesizedMarkdown` intact (restored if a retry replaced it) with
+          // `evaluation` unset, so overview.json still captures the synthesis.
+          const primaryMarkdown = original.synthesizedMarkdown;
+          try {
+            const evalOpts: EvaluatorOptions = {
+              skipRubric: synthesisConfig.skipEval,
+            };
+            if (synthesisConfig.evalModel) {
+              evalOpts.model = synthesisConfig.evalModel;
+            }
+            let evalResult = await evaluateSkill(original.synthesizedMarkdown, evalOpts);
 
-          // Soft threshold: a SINGLE bounded re-synthesis retry when the
-          // overall score is below threshold. The candidate is never dropped
-          // — we keep whichever attempt scored higher and let the UI flag
-          // low scores. The retry only makes sense when the rubric is available;
-          // with --skip-eval the structural-only score can't improve, so skip it.
-          const threshold = synthesisConfig.evalThreshold ?? 60;
-          if (!synthesisConfig.skipEval && shouldRetrySynthesis(evalResult.overallScore, threshold)) {
-            console.error(
-              `[crune]   [${i + 1}/${total}] Score ${evalResult.overallScore ?? 0} < ${threshold}, re-synthesizing once...`
-            );
-            const retry = await synthesizeWithClaude(prompt, synthOpts);
-            if (retry.success) {
-              const retryMarkdown = stripSynthesisPreamble(retry.stdout);
-              const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
-              if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
-                original.synthesizedMarkdown = retryMarkdown;
-                evalResult = retryEval;
+            // Soft threshold: a SINGLE bounded re-synthesis retry when the
+            // overall score is below threshold. The candidate is never dropped
+            // — we keep whichever attempt scored higher and let the UI flag
+            // low scores. The retry only makes sense when the rubric is available;
+            // with --skip-eval the structural-only score can't improve, so skip it.
+            const threshold = synthesisConfig.evalThreshold ?? 60;
+            if (!synthesisConfig.skipEval && shouldRetrySynthesis(evalResult.overallScore, threshold)) {
+              console.error(
+                `[crune]   [${i + 1}/${total}] Score ${evalResult.overallScore ?? 0} < ${threshold}, re-synthesizing once...`
+              );
+              const retry = await synthesizeWithClaude(prompt, synthOpts);
+              if (retry.success) {
+                const retryMarkdown = stripSynthesisPreamble(retry.stdout);
+                const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
+                if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
+                  original.synthesizedMarkdown = retryMarkdown;
+                  evalResult = retryEval;
+                }
               }
             }
-          }
 
-          original.evaluation = toSkillEvaluation(evalResult);
+            original.evaluation = toSkillEvaluation(evalResult);
+          } catch (err) {
+            // Restore the primary synthesis output (a retry may have replaced it
+            // before the throw) and leave evaluation unset. Synthesis output is
+            // primary; evaluation must never destroy it.
+            original.synthesizedMarkdown = primaryMarkdown;
+            original.evaluation = undefined;
+            console.error(
+              `[crune]   [${i + 1}/${total}] Evaluation failed (keeping synthesized markdown): ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
         }
         console.error(`[crune]   [${i + 1}/${total}] Done.`);
       } else {

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -19,7 +19,7 @@ import {
   type SemanticKnowledgeGraph,
 } from "./knowledge-graph-builder.js";
 import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions } from "./skill-synthesizer.js";
-import { evaluateSkill, toSkillEvaluation, type EvaluatorOptions } from "./skill-evaluator.js";
+import { evaluateSkill, toSkillEvaluation, shouldRetrySynthesis, type EvaluatorOptions } from "./skill-evaluator.js";
 import { generateSessionSummary } from "./session-summarizer.js";
 import {
   discoverSessions,
@@ -46,6 +46,7 @@ export interface CliArgs {
   skipFacets: boolean;
   skipEval: boolean;
   evalModel?: string;
+  evalThreshold: number;
 }
 
 /**
@@ -63,6 +64,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let skipFacets = false;
   let skipEval = false;
   let evalModel: string | undefined;
+  let evalThreshold = 60;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--sessions-dir" && args[i + 1]) {
@@ -89,6 +91,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       skipEval = true;
     } else if (args[i] === "--eval-model" && args[i + 1]) {
       evalModel = args[++i];
+    } else if (args[i] === "--eval-threshold" && args[i + 1]) {
+      const raw = parseInt(args[++i], 10);
+      evalThreshold = Number.isNaN(raw) ? 60 : Math.min(100, Math.max(0, raw));
     }
   }
   return {
@@ -101,6 +106,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     skipFacets,
     skipEval,
     evalModel,
+    evalThreshold,
   };
 }
 
@@ -566,8 +572,7 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
       if (result.success) {
         const original = knowledgeGraph.skillCandidates.find((sc) => sc.topicId === candidate.topicId);
         if (original) {
-          const markdown = stripSynthesisPreamble(result.stdout);
-          original.synthesizedMarkdown = markdown;
+          original.synthesizedMarkdown = stripSynthesisPreamble(result.stdout);
 
           // Evaluate the synthesized SKILL.md. Gated behind synthesis success
           // so heuristic markdown (skillMarkdown) is never scored. Rubric runs
@@ -577,7 +582,28 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
             if (synthesisConfig.evalModel) {
               evalOpts.model = synthesisConfig.evalModel;
             }
-            const evalResult = await evaluateSkill(markdown, evalOpts);
+            let evalResult = await evaluateSkill(original.synthesizedMarkdown, evalOpts);
+
+            // Soft threshold: a SINGLE bounded re-synthesis retry when the
+            // overall score is below threshold. The candidate is never dropped
+            // — we keep whichever attempt scored higher and let the UI flag
+            // low scores.
+            const threshold = synthesisConfig.evalThreshold ?? 60;
+            if (shouldRetrySynthesis(evalResult.overallScore, threshold)) {
+              console.error(
+                `[crune]   [${i + 1}/${total}] Score ${evalResult.overallScore ?? 0} < ${threshold}, re-synthesizing once...`
+              );
+              const retry = await synthesizeWithClaude(prompt, synthOpts);
+              if (retry.success) {
+                const retryMarkdown = stripSynthesisPreamble(retry.stdout);
+                const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
+                if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
+                  original.synthesizedMarkdown = retryMarkdown;
+                  evalResult = retryEval;
+                }
+              }
+            }
+
             original.evaluation = toSkillEvaluation(evalResult);
           }
         }
@@ -623,7 +649,7 @@ function getWeekLabel(date: Date): string {
 // ─── Main Pipeline ──────────────────────────────────────────────────────────
 
 async function main() {
-  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel } = parseArgs();
+  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel, evalThreshold } = parseArgs();
 
   console.error(`[crune] Sessions dir: ${sessionsDir}`);
   console.error(`[crune] Output dir:   ${outputDir}`);
@@ -747,6 +773,7 @@ async function main() {
     facetsDir: skipFacets ? undefined : facetsDir,
     skipEval,
     evalModel,
+    evalThreshold,
   });
   const overviewPath = path.join(outputDir, "overview.json");
   fs.writeFileSync(overviewPath, JSON.stringify(overviewData, null, 2));

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -19,6 +19,7 @@ import {
   type SemanticKnowledgeGraph,
 } from "./knowledge-graph-builder.js";
 import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions } from "./skill-synthesizer.js";
+import { evaluateSkill, toSkillEvaluation, type EvaluatorOptions } from "./skill-evaluator.js";
 import { generateSessionSummary } from "./session-summarizer.js";
 import {
   discoverSessions,
@@ -35,7 +36,7 @@ import {
 
 // ─── CLI argument parsing ───────────────────────────────────────────────────
 
-interface CliArgs {
+export interface CliArgs {
   sessionsDir: string;
   outputDir: string;
   skipSynthesis: boolean;
@@ -43,10 +44,16 @@ interface CliArgs {
   synthesisCount: number;
   facetsDir: string;
   skipFacets: boolean;
+  skipEval: boolean;
+  evalModel?: string;
 }
 
-function parseArgs(): CliArgs {
-  const args = process.argv.slice(2);
+/**
+ * Parse analyze-sessions CLI flags. `argv` defaults to `process.argv.slice(2)`
+ * but is injectable for unit testing.
+ */
+export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
+  const args = argv;
   let sessionsDir = path.join(os.homedir(), ".claude", "projects");
   let outputDir = path.resolve("public", "data", "sessions");
   let skipSynthesis = false;
@@ -54,6 +61,8 @@ function parseArgs(): CliArgs {
   let synthesisCount = 5;
   let facetsDir = path.join(os.homedir(), ".claude", "usage-data", "facets");
   let skipFacets = false;
+  let skipEval = false;
+  let evalModel: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--sessions-dir" && args[i + 1]) {
@@ -76,9 +85,23 @@ function parseArgs(): CliArgs {
       facetsDir = path.resolve(args[++i]);
     } else if (args[i] === "--skip-facets") {
       skipFacets = true;
+    } else if (args[i] === "--skip-eval") {
+      skipEval = true;
+    } else if (args[i] === "--eval-model" && args[i + 1]) {
+      evalModel = args[++i];
     }
   }
-  return { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets };
+  return {
+    sessionsDir,
+    outputDir,
+    skipSynthesis,
+    synthesisModel,
+    synthesisCount,
+    facetsDir,
+    skipFacets,
+    skipEval,
+    evalModel,
+  };
 }
 
 // ─── Output types ───────────────────────────────────────────────────────────
@@ -252,6 +275,9 @@ interface SynthesisConfig {
   model?: string;
   count: number;
   facetsDir?: string;
+  skipEval?: boolean;
+  evalModel?: string;
+  evalThreshold?: number;
 }
 
 async function generateOverview(sessions: ParsedSession[], synthesisConfig: SynthesisConfig = { skip: false, count: 5 }): Promise<OverviewJson> {
@@ -540,7 +566,20 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
       if (result.success) {
         const original = knowledgeGraph.skillCandidates.find((sc) => sc.topicId === candidate.topicId);
         if (original) {
-          original.synthesizedMarkdown = stripSynthesisPreamble(result.stdout);
+          const markdown = stripSynthesisPreamble(result.stdout);
+          original.synthesizedMarkdown = markdown;
+
+          // Evaluate the synthesized SKILL.md. Gated behind synthesis success
+          // so heuristic markdown (skillMarkdown) is never scored. Rubric runs
+          // via claude -p unless --skip-eval is set.
+          if (!synthesisConfig.skipEval) {
+            const evalOpts: EvaluatorOptions = {};
+            if (synthesisConfig.evalModel) {
+              evalOpts.model = synthesisConfig.evalModel;
+            }
+            const evalResult = await evaluateSkill(markdown, evalOpts);
+            original.evaluation = toSkillEvaluation(evalResult);
+          }
         }
         console.error(`[crune]   [${i + 1}/${total}] Done.`);
       } else {
@@ -584,7 +623,7 @@ function getWeekLabel(date: Date): string {
 // ─── Main Pipeline ──────────────────────────────────────────────────────────
 
 async function main() {
-  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets } = parseArgs();
+  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel } = parseArgs();
 
   console.error(`[crune] Sessions dir: ${sessionsDir}`);
   console.error(`[crune] Output dir:   ${outputDir}`);
@@ -706,6 +745,8 @@ async function main() {
     model: synthesisModel,
     count: synthesisCount,
     facetsDir: skipFacets ? undefined : facetsDir,
+    skipEval,
+    evalModel,
   });
   const overviewPath = path.join(outputDir, "overview.json");
   fs.writeFileSync(overviewPath, JSON.stringify(overviewData, null, 2));
@@ -724,7 +765,11 @@ async function main() {
   console.error(`[crune] Done.`);
 }
 
-main().catch((err) => {
-  console.error(`[crune] Fatal error: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Entry point — skip under Vitest so the module can be imported for unit tests
+// (e.g. parseArgs) without triggering the full pipeline.
+if (!process.env.VITEST) {
+  main().catch((err) => {
+    console.error(`[crune] Fatal error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -575,37 +575,39 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
           original.synthesizedMarkdown = stripSynthesisPreamble(result.stdout);
 
           // Evaluate the synthesized SKILL.md. Gated behind synthesis success
-          // so heuristic markdown (skillMarkdown) is never scored. Rubric runs
-          // via claude -p unless --skip-eval is set.
-          if (!synthesisConfig.skipEval) {
-            const evalOpts: EvaluatorOptions = {};
-            if (synthesisConfig.evalModel) {
-              evalOpts.model = synthesisConfig.evalModel;
-            }
-            let evalResult = await evaluateSkill(original.synthesizedMarkdown, evalOpts);
+          // so heuristic markdown (skillMarkdown) is never scored. Structural
+          // validation ALWAYS runs locally; --skip-eval only turns off the LLM
+          // rubric (structural-only mode).
+          const evalOpts: EvaluatorOptions = {
+            skipRubric: synthesisConfig.skipEval,
+          };
+          if (synthesisConfig.evalModel) {
+            evalOpts.model = synthesisConfig.evalModel;
+          }
+          let evalResult = await evaluateSkill(original.synthesizedMarkdown, evalOpts);
 
-            // Soft threshold: a SINGLE bounded re-synthesis retry when the
-            // overall score is below threshold. The candidate is never dropped
-            // — we keep whichever attempt scored higher and let the UI flag
-            // low scores.
-            const threshold = synthesisConfig.evalThreshold ?? 60;
-            if (shouldRetrySynthesis(evalResult.overallScore, threshold)) {
-              console.error(
-                `[crune]   [${i + 1}/${total}] Score ${evalResult.overallScore ?? 0} < ${threshold}, re-synthesizing once...`
-              );
-              const retry = await synthesizeWithClaude(prompt, synthOpts);
-              if (retry.success) {
-                const retryMarkdown = stripSynthesisPreamble(retry.stdout);
-                const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
-                if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
-                  original.synthesizedMarkdown = retryMarkdown;
-                  evalResult = retryEval;
-                }
+          // Soft threshold: a SINGLE bounded re-synthesis retry when the
+          // overall score is below threshold. The candidate is never dropped
+          // — we keep whichever attempt scored higher and let the UI flag
+          // low scores. The retry only makes sense when the rubric is available;
+          // with --skip-eval the structural-only score can't improve, so skip it.
+          const threshold = synthesisConfig.evalThreshold ?? 60;
+          if (!synthesisConfig.skipEval && shouldRetrySynthesis(evalResult.overallScore, threshold)) {
+            console.error(
+              `[crune]   [${i + 1}/${total}] Score ${evalResult.overallScore ?? 0} < ${threshold}, re-synthesizing once...`
+            );
+            const retry = await synthesizeWithClaude(prompt, synthOpts);
+            if (retry.success) {
+              const retryMarkdown = stripSynthesisPreamble(retry.stdout);
+              const retryEval = await evaluateSkill(retryMarkdown, evalOpts);
+              if ((retryEval.overallScore ?? 0) >= (evalResult.overallScore ?? 0)) {
+                original.synthesizedMarkdown = retryMarkdown;
+                evalResult = retryEval;
               }
             }
-
-            original.evaluation = toSkillEvaluation(evalResult);
           }
+
+          original.evaluation = toSkillEvaluation(evalResult);
         }
         console.error(`[crune]   [${i + 1}/${total}] Done.`);
       } else {

--- a/scripts/skill-evaluator.ts
+++ b/scripts/skill-evaluator.ts
@@ -512,10 +512,14 @@ export async function evaluateSkill(
   const structural = validateStructure(markdown);
 
   let rubric: RubricResult | undefined;
-  if (!options.skipRubric) {
-    rubric = await scoreWithRubric(markdown, options);
-  } else {
+  if (options.skipRubric) {
     rubric = { ok: false, skipped: true };
+  } else if (!structural.valid) {
+    // Structural validation failed -> overallScore is forced to 0 regardless of
+    // the rubric, so the (expensive) claude -p rubric call would be wasted.
+    rubric = { ok: false, skipped: true };
+  } else {
+    rubric = await scoreWithRubric(markdown, options);
   }
 
   const smokeFiring = await smokeFireTest(markdown);

--- a/scripts/skill-evaluator.ts
+++ b/scripts/skill-evaluator.ts
@@ -534,6 +534,24 @@ export async function evaluateSkill(
   return { structural, rubric, smokeFiring, overallScore };
 }
 
+// ---------- Soft threshold ----------
+
+/**
+ * Decide whether to trigger a (single, bounded) re-synthesis retry for a
+ * skill whose evaluation scored below the soft threshold.
+ *
+ * Pure decision function — the caller owns the actual retry budget (exactly
+ * one extra `claude -p` call). A missing score is treated as 0. A threshold
+ * of 0 disables retries entirely.
+ */
+export function shouldRetrySynthesis(
+  overallScore: number | undefined,
+  threshold: number
+): boolean {
+  if (threshold <= 0) return false;
+  return (overallScore ?? 0) < threshold;
+}
+
 // ---------- Persistence mapper ----------
 
 /**

--- a/scripts/skill-evaluator.ts
+++ b/scripts/skill-evaluator.ts
@@ -11,6 +11,7 @@
  */
 import { spawn } from "node:child_process";
 import { z } from "zod";
+import type { SkillEvaluation } from "../src/types/session.js";
 
 // ---------- Types ----------
 
@@ -531,4 +532,49 @@ export async function evaluateSkill(
   }
 
   return { structural, rubric, smokeFiring, overallScore };
+}
+
+// ---------- Persistence mapper ----------
+
+/**
+ * Convert an internal {@link EvaluationResult} into the persistable
+ * {@link SkillEvaluation} shape from src/types/session.ts.
+ *
+ * Drops fields that are not safe / useful to serialize into overview.json:
+ *   - `rubric.rawResponse` (raw LLM text, potentially large/noisy)
+ *   - `structural.parsed` (intermediate parse, not part of the UI shape)
+ *
+ * Everything else (structural validity + issues, rubric score/breakdown/hints/
+ * error/skipped, smoke firing, overall score) is preserved verbatim.
+ */
+export function toSkillEvaluation(result: EvaluationResult): SkillEvaluation {
+  const out: SkillEvaluation = {
+    structural: {
+      valid: result.structural.valid,
+      issues: result.structural.issues.map((i) => ({
+        field: i.field,
+        message: i.message,
+      })),
+    },
+    smokeFiring: {
+      skipped: result.smokeFiring.skipped,
+      message: result.smokeFiring.message,
+    },
+    overallScore: result.overallScore,
+  };
+
+  if (result.rubric) {
+    out.rubric = {
+      ok: result.rubric.ok,
+      score: result.rubric.score,
+      breakdown: result.rubric.breakdown
+        ? { ...result.rubric.breakdown }
+        : undefined,
+      hints: result.rubric.hints ? [...result.rubric.hints] : undefined,
+      error: result.rubric.error,
+      skipped: result.rubric.skipped,
+    };
+  }
+
+  return out;
 }

--- a/src/components/knowledge/KnowledgeNodeDetail.css
+++ b/src/components/knowledge/KnowledgeNodeDetail.css
@@ -475,3 +475,108 @@
 .knd-synth-copy-btn:hover {
   background-color: rgba(22, 163, 74, 0.15);
 }
+
+/* ── Skill Evaluation Badge ─────────────────────────────────────── */
+.knd-eval {
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  background: var(--bg-tertiary);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.knd-eval--pass {
+  border-left-color: var(--success);
+}
+
+.knd-eval--borderline {
+  border-left-color: var(--warning);
+}
+
+.knd-eval--fail {
+  border-left-color: var(--danger);
+}
+
+.knd-eval-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.knd-eval-chip {
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.knd-eval-chip--ok {
+  color: var(--success);
+  background-color: rgba(22, 163, 74, 0.1);
+}
+
+.knd-eval-chip--ng {
+  color: var(--danger);
+  background-color: rgba(220, 38, 38, 0.1);
+}
+
+.knd-eval-score {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.knd-eval-issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.knd-eval-issue {
+  font-size: 11px;
+  color: var(--danger);
+}
+
+.knd-eval-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.knd-eval-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.knd-eval-hints-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.knd-eval-hints-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.knd-eval-hint {
+  font-size: 11px;
+  color: var(--text-primary);
+  line-height: 1.4;
+}

--- a/src/components/knowledge/KnowledgeNodeDetail.tsx
+++ b/src/components/knowledge/KnowledgeNodeDetail.tsx
@@ -1,68 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedToolSequence, KnowledgeCommunity, SkillEvaluation } from '../../types'
+import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedToolSequence, KnowledgeCommunity } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
+import { SkillEvaluationBadge } from './SkillEvaluationBadge'
 import './KnowledgeNodeDetail.css'
-
-/** Map an overall score (0-100) to a pass/borderline/fail status tone. */
-function evalStatus(evaluation: SkillEvaluation): 'pass' | 'borderline' | 'fail' {
-  if (!evaluation.structural.valid) return 'fail'
-  const score = evaluation.overallScore ?? 0
-  if (score >= 70) return 'pass'
-  if (score >= 50) return 'borderline'
-  return 'fail'
-}
-
-/**
- * Compact評価バッジ: 構造の合否、総合スコア、rubric内訳、改善ヒントを表示する。
- */
-function SkillEvaluationBadge({ evaluation }: { evaluation: SkillEvaluation }) {
-  const status = evalStatus(evaluation)
-  const score = evaluation.overallScore ?? 0
-  const rubric = evaluation.rubric
-  const hints = rubric?.hints ?? []
-
-  return (
-    <div className={`knd-eval knd-eval--${status}`}>
-      <div className="knd-eval-header">
-        <span className={`knd-eval-chip knd-eval-chip--${evaluation.structural.valid ? 'ok' : 'ng'}`}>
-          構造 {evaluation.structural.valid ? 'OK' : 'NG'}
-        </span>
-        <span className="knd-eval-score">スコア {score}/100</span>
-      </div>
-
-      {!evaluation.structural.valid && evaluation.structural.issues.length > 0 && (
-        <ul className="knd-eval-issues">
-          {evaluation.structural.issues.map((issue, i) => (
-            <li key={i} className="knd-eval-issue">
-              <strong>{issue.field}</strong>: {issue.message}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {rubric?.ok && rubric.breakdown && (
-        <div className="knd-eval-breakdown">
-          <span>名前 {rubric.breakdown.nameQuality}/25</span>
-          <span>説明 {rubric.breakdown.descriptionTriggering}/25</span>
-          <span>手順 {rubric.breakdown.instructionsConcrete}/25</span>
-          <span>ノイズ {rubric.breakdown.noPreambleNoise}/25</span>
-        </div>
-      )}
-
-      {hints.length > 0 && (
-        <div className="knd-eval-hints">
-          <span className="knd-eval-hints-label">改善ヒント</span>
-          <ul className="knd-eval-hints-list">
-            {hints.map((hint, i) => (
-              <li key={i} className="knd-eval-hint">{hint}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  )
-}
 
 interface Props {
   node: TopicNode | null
@@ -249,7 +190,7 @@ export function KnowledgeNodeDetail({
           <div className="knd-export">
             {/* Skill evaluation badge (from analyze-sessions eval pipeline) */}
             {skillCandidate.evaluation && (
-              <SkillEvaluationBadge evaluation={skillCandidate.evaluation} />
+              <SkillEvaluationBadge evaluation={skillCandidate.evaluation} prefix="knd" />
             )}
             {/* Pre-synthesized result (from analyze-sessions) */}
             {skillCandidate.synthesizedMarkdown && !synthResult && (

--- a/src/components/knowledge/KnowledgeNodeDetail.tsx
+++ b/src/components/knowledge/KnowledgeNodeDetail.tsx
@@ -1,8 +1,68 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedToolSequence, KnowledgeCommunity } from '../../types'
+import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedToolSequence, KnowledgeCommunity, SkillEvaluation } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import './KnowledgeNodeDetail.css'
+
+/** Map an overall score (0-100) to a pass/borderline/fail status tone. */
+function evalStatus(evaluation: SkillEvaluation): 'pass' | 'borderline' | 'fail' {
+  if (!evaluation.structural.valid) return 'fail'
+  const score = evaluation.overallScore ?? 0
+  if (score >= 70) return 'pass'
+  if (score >= 50) return 'borderline'
+  return 'fail'
+}
+
+/**
+ * Compact評価バッジ: 構造の合否、総合スコア、rubric内訳、改善ヒントを表示する。
+ */
+function SkillEvaluationBadge({ evaluation }: { evaluation: SkillEvaluation }) {
+  const status = evalStatus(evaluation)
+  const score = evaluation.overallScore ?? 0
+  const rubric = evaluation.rubric
+  const hints = rubric?.hints ?? []
+
+  return (
+    <div className={`knd-eval knd-eval--${status}`}>
+      <div className="knd-eval-header">
+        <span className={`knd-eval-chip knd-eval-chip--${evaluation.structural.valid ? 'ok' : 'ng'}`}>
+          構造 {evaluation.structural.valid ? 'OK' : 'NG'}
+        </span>
+        <span className="knd-eval-score">スコア {score}/100</span>
+      </div>
+
+      {!evaluation.structural.valid && evaluation.structural.issues.length > 0 && (
+        <ul className="knd-eval-issues">
+          {evaluation.structural.issues.map((issue, i) => (
+            <li key={i} className="knd-eval-issue">
+              <strong>{issue.field}</strong>: {issue.message}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {rubric?.ok && rubric.breakdown && (
+        <div className="knd-eval-breakdown">
+          <span>名前 {rubric.breakdown.nameQuality}/25</span>
+          <span>説明 {rubric.breakdown.descriptionTriggering}/25</span>
+          <span>手順 {rubric.breakdown.instructionsConcrete}/25</span>
+          <span>ノイズ {rubric.breakdown.noPreambleNoise}/25</span>
+        </div>
+      )}
+
+      {hints.length > 0 && (
+        <div className="knd-eval-hints">
+          <span className="knd-eval-hints-label">改善ヒント</span>
+          <ul className="knd-eval-hints-list">
+            {hints.map((hint, i) => (
+              <li key={i} className="knd-eval-hint">{hint}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
 
 interface Props {
   node: TopicNode | null
@@ -187,6 +247,10 @@ export function KnowledgeNodeDetail({
         {/* Distill Skill */}
         {skillCandidate && (
           <div className="knd-export">
+            {/* Skill evaluation badge (from analyze-sessions eval pipeline) */}
+            {skillCandidate.evaluation && (
+              <SkillEvaluationBadge evaluation={skillCandidate.evaluation} />
+            )}
             {/* Pre-synthesized result (from analyze-sessions) */}
             {skillCandidate.synthesizedMarkdown && !synthResult && (
               <div className="knd-synth-result">

--- a/src/components/knowledge/SkillEvaluationBadge.css
+++ b/src/components/knowledge/SkillEvaluationBadge.css
@@ -1,0 +1,10 @@
+/*
+ * SkillEvaluationBadge is intentionally prefix-driven: each host view (Knowledge
+ * Node Detail `knd`, Tacit Knowledge `tk`) supplies its own `prefix` prop and
+ * owns the concrete `.{prefix}-eval*` rules in its co-located stylesheet so the
+ * badge inherits the surrounding view's sizing/spacing. The markup and the
+ * pass/borderline/fail thresholds live once in SkillEvaluationBadge.tsx.
+ *
+ * This file is the badge's co-located stylesheet entrypoint; host-specific
+ * visual rules remain in KnowledgeNodeDetail.css / TacitKnowledgeView.css.
+ */

--- a/src/components/knowledge/SkillEvaluationBadge.tsx
+++ b/src/components/knowledge/SkillEvaluationBadge.tsx
@@ -1,0 +1,69 @@
+import type { SkillEvaluation } from '../../types'
+import './SkillEvaluationBadge.css'
+
+/** Map an evaluation to a pass/borderline/fail status tone (structural NG -> fail). */
+function evalStatus(evaluation: SkillEvaluation): 'pass' | 'borderline' | 'fail' {
+  if (!evaluation.structural.valid) return 'fail'
+  const score = evaluation.overallScore ?? 0
+  if (score >= 70) return 'pass'
+  if (score >= 50) return 'borderline'
+  return 'fail'
+}
+
+interface Props {
+  evaluation: SkillEvaluation
+  /**
+   * CSS class prefix so each host view can keep its own visual styling.
+   * e.g. `knd` -> `knd-eval`, `tk` -> `tk-eval`.
+   */
+  prefix: string
+}
+
+/** Compact評価バッジ: 構造の合否、総合スコア、rubric内訳、改善ヒントを表示する。 */
+export function SkillEvaluationBadge({ evaluation, prefix }: Props) {
+  const status = evalStatus(evaluation)
+  const score = evaluation.overallScore ?? 0
+  const rubric = evaluation.rubric
+  const hints = rubric?.hints ?? []
+
+  return (
+    <div className={`${prefix}-eval ${prefix}-eval--${status}`}>
+      <div className={`${prefix}-eval-header`}>
+        <span className={`${prefix}-eval-chip ${prefix}-eval-chip--${evaluation.structural.valid ? 'ok' : 'ng'}`}>
+          構造 {evaluation.structural.valid ? 'OK' : 'NG'}
+        </span>
+        <span className={`${prefix}-eval-score`}>スコア {score}/100</span>
+      </div>
+
+      {!evaluation.structural.valid && evaluation.structural.issues.length > 0 && (
+        <ul className={`${prefix}-eval-issues`}>
+          {evaluation.structural.issues.map((issue, i) => (
+            <li key={i} className={`${prefix}-eval-issue`}>
+              <strong>{issue.field}</strong>: {issue.message}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {rubric?.ok && rubric.breakdown && (
+        <div className={`${prefix}-eval-breakdown`}>
+          <span>名前 {rubric.breakdown.nameQuality}/25</span>
+          <span>説明 {rubric.breakdown.descriptionTriggering}/25</span>
+          <span>手順 {rubric.breakdown.instructionsConcrete}/25</span>
+          <span>ノイズ {rubric.breakdown.noPreambleNoise}/25</span>
+        </div>
+      )}
+
+      {hints.length > 0 && (
+        <div className={`${prefix}-eval-hints`}>
+          <span className={`${prefix}-eval-hints-label`}>改善ヒント</span>
+          <ul className={`${prefix}-eval-hints-list`}>
+            {hints.map((hint, i) => (
+              <li key={i} className={`${prefix}-eval-hint`}>{hint}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/knowledge/TacitKnowledgeView.css
+++ b/src/components/knowledge/TacitKnowledgeView.css
@@ -247,12 +247,40 @@
   color: var(--text-primary);
 }
 
+.tk-eval-issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tk-eval-issue {
+  font-size: 10px;
+  color: var(--danger);
+}
+
 .tk-eval-breakdown {
   display: flex;
   flex-wrap: wrap;
   gap: 3px 8px;
   font-size: 10px;
   color: var(--text-secondary);
+}
+
+.tk-eval-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tk-eval-hints-label {
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .tk-eval-hints-list {

--- a/src/components/knowledge/TacitKnowledgeView.css
+++ b/src/components/knowledge/TacitKnowledgeView.css
@@ -192,3 +192,80 @@
   line-height: 1.5;
 }
 
+
+/* ── Skill Evaluation Badge ─────────────────────────────────────── */
+.tk-eval {
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin: 6px 0;
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.tk-eval--pass {
+  border-left-color: var(--success);
+}
+
+.tk-eval--borderline {
+  border-left-color: var(--warning);
+}
+
+.tk-eval--fail {
+  border-left-color: var(--danger);
+}
+
+.tk-eval-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tk-eval-chip {
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 3px;
+  padding: 2px 5px;
+}
+
+.tk-eval-chip--ok {
+  color: var(--success);
+  background-color: rgba(22, 163, 74, 0.1);
+}
+
+.tk-eval-chip--ng {
+  color: var(--danger);
+  background-color: rgba(220, 38, 38, 0.1);
+}
+
+.tk-eval-score {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tk-eval-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 8px;
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.tk-eval-hints-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tk-eval-hint {
+  font-size: 10px;
+  color: var(--text-primary);
+  line-height: 1.4;
+}

--- a/src/components/knowledge/TacitKnowledgeView.tsx
+++ b/src/components/knowledge/TacitKnowledgeView.tsx
@@ -1,8 +1,53 @@
 import { useState, useCallback } from 'react'
-import type { KnowledgeGraphMetrics, TopicNode, TopicEdge, KnowledgeCommunity, TacitKnowledge, SkillCandidate, EnrichedToolSequence } from '../../types'
+import type { KnowledgeGraphMetrics, TopicNode, TopicEdge, KnowledgeCommunity, TacitKnowledge, SkillCandidate, EnrichedToolSequence, SkillEvaluation } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import './TacitKnowledgeView.css'
+
+/** Map an overall score (0-100) to a pass/borderline/fail status tone. */
+function tkEvalStatus(evaluation: SkillEvaluation): 'pass' | 'borderline' | 'fail' {
+  if (!evaluation.structural.valid) return 'fail'
+  const score = evaluation.overallScore ?? 0
+  if (score >= 70) return 'pass'
+  if (score >= 50) return 'borderline'
+  return 'fail'
+}
+
+/** Compact評価バッジ: 構造の合否、総合スコア、rubric内訳、改善ヒントを表示する。 */
+function SkillEvaluationBadge({ evaluation }: { evaluation: SkillEvaluation }) {
+  const status = tkEvalStatus(evaluation)
+  const score = evaluation.overallScore ?? 0
+  const rubric = evaluation.rubric
+  const hints = rubric?.hints ?? []
+
+  return (
+    <div className={`tk-eval tk-eval--${status}`}>
+      <div className="tk-eval-header">
+        <span className={`tk-eval-chip tk-eval-chip--${evaluation.structural.valid ? 'ok' : 'ng'}`}>
+          構造 {evaluation.structural.valid ? 'OK' : 'NG'}
+        </span>
+        <span className="tk-eval-score">スコア {score}/100</span>
+      </div>
+
+      {rubric?.ok && rubric.breakdown && (
+        <div className="tk-eval-breakdown">
+          <span>名前 {rubric.breakdown.nameQuality}/25</span>
+          <span>説明 {rubric.breakdown.descriptionTriggering}/25</span>
+          <span>手順 {rubric.breakdown.instructionsConcrete}/25</span>
+          <span>ノイズ {rubric.breakdown.noPreambleNoise}/25</span>
+        </div>
+      )}
+
+      {hints.length > 0 && (
+        <ul className="tk-eval-hints-list">
+          {hints.map((hint, i) => (
+            <li key={i} className="tk-eval-hint">{hint}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
 
 interface Props {
   knowledge: TacitKnowledge | null
@@ -272,6 +317,9 @@ export function TacitKnowledgeView({ knowledge, graphMetrics, topics, edges, com
                           <span className="tk-card-badge">Hook</span>
                         )}
                       </div>
+                      {candidate.evaluation && (
+                        <SkillEvaluationBadge evaluation={candidate.evaluation} />
+                      )}
                       <DistillButton
                         candidate={candidate}
                         topic={topic}

--- a/src/components/knowledge/TacitKnowledgeView.tsx
+++ b/src/components/knowledge/TacitKnowledgeView.tsx
@@ -1,53 +1,9 @@
 import { useState, useCallback } from 'react'
-import type { KnowledgeGraphMetrics, TopicNode, TopicEdge, KnowledgeCommunity, TacitKnowledge, SkillCandidate, EnrichedToolSequence, SkillEvaluation } from '../../types'
+import type { KnowledgeGraphMetrics, TopicNode, TopicEdge, KnowledgeCommunity, TacitKnowledge, SkillCandidate, EnrichedToolSequence } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
+import { SkillEvaluationBadge } from './SkillEvaluationBadge'
 import './TacitKnowledgeView.css'
-
-/** Map an overall score (0-100) to a pass/borderline/fail status tone. */
-function tkEvalStatus(evaluation: SkillEvaluation): 'pass' | 'borderline' | 'fail' {
-  if (!evaluation.structural.valid) return 'fail'
-  const score = evaluation.overallScore ?? 0
-  if (score >= 70) return 'pass'
-  if (score >= 50) return 'borderline'
-  return 'fail'
-}
-
-/** Compact評価バッジ: 構造の合否、総合スコア、rubric内訳、改善ヒントを表示する。 */
-function SkillEvaluationBadge({ evaluation }: { evaluation: SkillEvaluation }) {
-  const status = tkEvalStatus(evaluation)
-  const score = evaluation.overallScore ?? 0
-  const rubric = evaluation.rubric
-  const hints = rubric?.hints ?? []
-
-  return (
-    <div className={`tk-eval tk-eval--${status}`}>
-      <div className="tk-eval-header">
-        <span className={`tk-eval-chip tk-eval-chip--${evaluation.structural.valid ? 'ok' : 'ng'}`}>
-          構造 {evaluation.structural.valid ? 'OK' : 'NG'}
-        </span>
-        <span className="tk-eval-score">スコア {score}/100</span>
-      </div>
-
-      {rubric?.ok && rubric.breakdown && (
-        <div className="tk-eval-breakdown">
-          <span>名前 {rubric.breakdown.nameQuality}/25</span>
-          <span>説明 {rubric.breakdown.descriptionTriggering}/25</span>
-          <span>手順 {rubric.breakdown.instructionsConcrete}/25</span>
-          <span>ノイズ {rubric.breakdown.noPreambleNoise}/25</span>
-        </div>
-      )}
-
-      {hints.length > 0 && (
-        <ul className="tk-eval-hints-list">
-          {hints.map((hint, i) => (
-            <li key={i} className="tk-eval-hint">{hint}</li>
-          ))}
-        </ul>
-      )}
-    </div>
-  )
-}
 
 interface Props {
   knowledge: TacitKnowledge | null
@@ -318,7 +274,7 @@ export function TacitKnowledgeView({ knowledge, graphMetrics, topics, edges, com
                         )}
                       </div>
                       {candidate.evaluation && (
-                        <SkillEvaluationBadge evaluation={candidate.evaluation} />
+                        <SkillEvaluationBadge evaluation={candidate.evaluation} prefix="tk" />
                       )}
                       <DistillButton
                         candidate={candidate}


### PR DESCRIPTION
Closes #20

評価器コア（構造検証＋LLMルーブリック＋orchestrator）は実装済みだったため、残差を実装。

## What
1. `toSkillEvaluation()` mapper（内部 EvaluationResult → 永続化用 SkillEvaluation、rawResponse等を除去）
2. `analyze-sessions` の synthesis ループへ配線 → `candidate.evaluation` を overview.json に永続化（synthesis成功時のみ採点）。`--skip-eval` / `--eval-model` フラグ追加（評価は既定ON）
3. soft閾値 `--eval-threshold`（既定60、[0,100]クランプ）＋ 低スコア時に**1回だけ**再合成リトライ（高スコア側を採用、候補は落とさない）
4. Knowledge UI（KnowledgeNodeDetail / TacitKnowledgeView）に評価バッジ（構造OK/NG・スコア/100・ルーブリック内訳・改善ヒント、日本語）
5. CLAUDE.md 更新

## Tests
11件追加（mapper 6・閾値判定 4・フラグparse 8相当）。全282 green。

## スコープ外（指示どおり）
smoke firing test は既存stubのまま（別issue化）。`src/types/session.ts` は既存 SkillEvaluation で十分のため未変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)