### PR TITLE
Session Playback: readability improvements + bookmark/tag/annotate feedback (#22 #23)

### DIFF
--- a/src/components/playback/PlaybackStep.tsx
+++ b/src/components/playback/PlaybackStep.tsx
@@ -55,11 +55,12 @@ export function PlaybackStep({ turn, isActive, subagents, depth = 0 }: Props) {
       ))}
 
       {/* Tool calls */}
-      {toolCalls.map((tc) => (
+      {toolCalls.map((tc, i) => (
         <ToolCallBlock
-          key={tc.toolUseId}
+          key={tc.toolUseId || `idx-${i}`}
           toolCall={tc}
           turnId={turn.turnIndex}
+          index={i}
           subagents={subagents}
           depth={depth}
         />

--- a/src/components/playback/PlaybackStep.tsx
+++ b/src/components/playback/PlaybackStep.tsx
@@ -7,6 +7,8 @@ interface Props {
   turn: ConversationTurn
   isActive: boolean
   subagents: Record<string, SubagentSession>
+  /** Nesting depth for recursively-rendered subagent steps (0 = top level). */
+  depth?: number
 }
 
 function formatTimestamp(iso: string): string {
@@ -14,7 +16,7 @@ function formatTimestamp(iso: string): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
-export function PlaybackStep({ turn, isActive, subagents }: Props) {
+export function PlaybackStep({ turn, isActive, subagents, depth = 0 }: Props) {
   const [thinkingOpen, setThinkingOpen] = useState(false)
 
   const toolCalls = turn.toolCalls ?? []
@@ -58,6 +60,7 @@ export function PlaybackStep({ turn, isActive, subagents }: Props) {
           key={tc.toolUseId}
           toolCall={tc}
           subagents={subagents}
+          depth={depth}
         />
       ))}
     </div>

--- a/src/components/playback/PlaybackStep.tsx
+++ b/src/components/playback/PlaybackStep.tsx
@@ -59,6 +59,7 @@ export function PlaybackStep({ turn, isActive, subagents, depth = 0 }: Props) {
         <ToolCallBlock
           key={tc.toolUseId}
           toolCall={tc}
+          turnId={turn.turnIndex}
           subagents={subagents}
           depth={depth}
         />

--- a/src/components/playback/SessionPlayback.css
+++ b/src/components/playback/SessionPlayback.css
@@ -125,6 +125,80 @@
   color: var(--text-secondary);
 }
 
+/* Key-moments rail: labeled jump links */
+.playback-keymoments {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding: 6px 4px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+
+.keymoments-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.keymoments-links {
+  display: flex;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.keymoment-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background-color 0.15s;
+}
+
+.keymoment-link:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.keymoment-link--active {
+  border-color: var(--accent);
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.keymoment-kind {
+  font-weight: 600;
+}
+
+.keymoment-index {
+  font-family: monospace;
+  color: var(--text-tertiary);
+}
+
+.keymoment-link--agent .keymoment-kind {
+  color: var(--chart-2);
+}
+
+.keymoment-link--plan .keymoment-kind {
+  color: var(--chart-3);
+}
+
+.keymoment-link--prompt .keymoment-kind {
+  color: var(--chart-1);
+}
+
 /* Body layout: minimap + content + side panel */
 .playback-body {
   display: grid;

--- a/src/components/playback/SessionPlayback.css
+++ b/src/components/playback/SessionPlayback.css
@@ -265,6 +265,14 @@
   border-color: var(--accent);
 }
 
+/* Turn-level feedback cluster (bookmark / tags / note) */
+.playback-turn-feedback {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 5;
+}
+
 /* Dimmed + collapsed (filtered-out) turn */
 .playback-turn--filtered {
   opacity: 0.4;
@@ -416,5 +424,6 @@
 
 /* Turn items */
 .playback-turn {
+  position: relative;
   cursor: pointer;
 }

--- a/src/components/playback/SessionPlayback.css
+++ b/src/components/playback/SessionPlayback.css
@@ -199,6 +199,105 @@
   color: var(--chart-1);
 }
 
+/* Search / filter bar */
+.playback-filter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding: 8px 4px;
+  flex-wrap: wrap;
+}
+
+.filter-text {
+  flex: 1;
+  min-width: 200px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.filter-text:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.filter-tool {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.filter-keyturns {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.filter-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.filter-clear {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.filter-clear:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+/* Dimmed + collapsed (filtered-out) turn */
+.playback-turn--filtered {
+  opacity: 0.4;
+}
+
+.playback-turn--filtered:hover {
+  opacity: 0.7;
+}
+
+.playback-turn-collapsed {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.collapsed-index {
+  font-family: monospace;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.collapsed-prompt {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 /* Body layout: minimap + content + side panel */
 .playback-body {
   display: grid;

--- a/src/components/playback/SessionPlayback.tsx
+++ b/src/components/playback/SessionPlayback.tsx
@@ -4,6 +4,7 @@ import type { ConversationTurn, ToolCall } from '../../types'
 import { PlaybackStep } from './PlaybackStep.tsx'
 import { PlaybackSidePanel } from './PlaybackSidePanel.tsx'
 import { PlanModeContext } from './PlanModeContext.ts'
+import { selectKeyMoments } from './toolCallHelpers.ts'
 import './SessionPlayback.css'
 
 interface Props {
@@ -153,6 +154,15 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
 
+  // Jump to a turn from the key-moments rail: activate it and scroll into view.
+  const jumpToTurn = useCallback((index: number) => {
+    setActiveTurnIndex(index)
+    const el = turnRefs.current.get(index)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [])
+
   const setTurnRef = useCallback((index: number, el: HTMLDivElement | null) => {
     if (el) {
       turnRefs.current.set(index, el)
@@ -213,6 +223,12 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
       index: i,
     }))
   }, [turnMeasurements, scrollInfo.height, data])
+
+  // Semantic key-moments for the jump-link rail
+  const keyMoments = useMemo(
+    () => (data ? selectKeyMoments(data.turns) : []),
+    [data],
+  )
 
   // Viewport indicator position
   const viewportTopPct = (scrollInfo.top / scrollInfo.height) * 100
@@ -290,6 +306,26 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
           </div>
         ))}
       </div>
+
+      {/* Key-moments rail: labeled jump links to semantically important turns */}
+      {keyMoments.length > 0 && (
+        <div className="playback-keymoments" role="navigation" aria-label="重要な瞬間">
+          <span className="keymoments-label">重要な瞬間</span>
+          <div className="keymoments-links">
+            {keyMoments.map((moment) => (
+              <button
+                key={moment.index}
+                className={`keymoment-link keymoment-link--${moment.kind} ${moment.index === activeTurnIndex ? 'keymoment-link--active' : ''}`}
+                title={summarizeTurn(turns[moment.index])}
+                onClick={() => jumpToTurn(moment.index)}
+              >
+                <span className="keymoment-kind">{moment.label}</span>
+                <span className="keymoment-index">#{moment.index + 1}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="playback-body">
         {/* Minimap */}

--- a/src/components/playback/SessionPlayback.tsx
+++ b/src/components/playback/SessionPlayback.tsx
@@ -5,6 +5,7 @@ import { PlaybackStep } from './PlaybackStep.tsx'
 import { PlaybackSidePanel } from './PlaybackSidePanel.tsx'
 import { PlanModeContext } from './PlanModeContext.ts'
 import { FeedbackContext } from './feedback/FeedbackContext.ts'
+import { FeedbackCluster } from './feedback/FeedbackCluster.tsx'
 import { useSessionFeedback } from '../../hooks/useSessionFeedback.ts'
 import { selectKeyMoments, turnMatchesFilter } from './toolCallHelpers.ts'
 import type { PlaybackFilter } from './toolCallHelpers.ts'
@@ -472,11 +473,16 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
                     </span>
                   </div>
                 ) : (
-                  <PlaybackStep
-                    turn={turn}
-                    isActive={i === activeTurnIndex}
-                    subagents={subagents}
-                  />
+                  <>
+                    <div className="playback-turn-feedback">
+                      <FeedbackCluster turnId={turn.turnIndex} />
+                    </div>
+                    <PlaybackStep
+                      turn={turn}
+                      isActive={i === activeTurnIndex}
+                      subagents={subagents}
+                    />
+                  </>
                 )}
               </div>
             )

--- a/src/components/playback/SessionPlayback.tsx
+++ b/src/components/playback/SessionPlayback.tsx
@@ -4,6 +4,8 @@ import type { ConversationTurn, ToolCall } from '../../types'
 import { PlaybackStep } from './PlaybackStep.tsx'
 import { PlaybackSidePanel } from './PlaybackSidePanel.tsx'
 import { PlanModeContext } from './PlanModeContext.ts'
+import { FeedbackContext } from './feedback/FeedbackContext.ts'
+import { useSessionFeedback } from '../../hooks/useSessionFeedback.ts'
 import { selectKeyMoments, turnMatchesFilter } from './toolCallHelpers.ts'
 import type { PlaybackFilter } from './toolCallHelpers.ts'
 import './SessionPlayback.css'
@@ -60,6 +62,7 @@ function summarizeTurn(turn: ConversationTurn): string {
 
 export function SessionPlayback({ sessionId, onClose }: Props) {
   const { data, loading, error } = useSessionDetail(sessionId)
+  const feedback = useSessionFeedback(sessionId)
   const [activeTurnIndex, setActiveTurnIndex] = useState(0)
   const turnRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const contentRef = useRef<HTMLDivElement>(null)
@@ -293,6 +296,7 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
 
   return (
     <PlanModeContext.Provider value={isPlanMode}>
+      <FeedbackContext.Provider value={feedback}>
       <div className="session-playback">
       <div className="playback-header">
         <div className="playback-header-info">
@@ -482,6 +486,7 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
         <PlaybackSidePanel detail={data} />
       </div>
       </div>
+      </FeedbackContext.Provider>
     </PlanModeContext.Provider>
   )
 }

--- a/src/components/playback/SessionPlayback.tsx
+++ b/src/components/playback/SessionPlayback.tsx
@@ -4,7 +4,8 @@ import type { ConversationTurn, ToolCall } from '../../types'
 import { PlaybackStep } from './PlaybackStep.tsx'
 import { PlaybackSidePanel } from './PlaybackSidePanel.tsx'
 import { PlanModeContext } from './PlanModeContext.ts'
-import { selectKeyMoments } from './toolCallHelpers.ts'
+import { selectKeyMoments, turnMatchesFilter } from './toolCallHelpers.ts'
+import type { PlaybackFilter } from './toolCallHelpers.ts'
 import './SessionPlayback.css'
 
 interface Props {
@@ -65,6 +66,7 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
   const minimapRef = useRef<HTMLDivElement>(null)
   const isDragging = useRef(false)
   const [hoveredBar, setHoveredBar] = useState<{ index: number; x: number; y: number } | null>(null)
+  const [filter, setFilter] = useState<PlaybackFilter>({ text: '', toolName: '', keyTurnsOnly: false })
 
   // Turn measurements for minimap
   const [turnMeasurements, setTurnMeasurements] = useState<Array<{ top: number; height: number }>>([])
@@ -74,6 +76,7 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- resetting derived state on prop change is intentional
     setActiveTurnIndex(0)
+    setFilter({ text: '', toolName: '', keyTurnsOnly: false })
   }, [sessionId])
 
   // Measure turn positions after render
@@ -229,6 +232,34 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
     () => (data ? selectKeyMoments(data.turns) : []),
     [data],
   )
+  const keyIndices = useMemo(
+    () => new Set(keyMoments.map(m => m.index)),
+    [keyMoments],
+  )
+
+  // Distinct tool names present in the session, for the tool-name filter dropdown
+  const availableToolNames = useMemo(() => {
+    if (!data) return []
+    const names = new Set<string>()
+    for (const turn of data.turns) {
+      for (const tc of turn.toolCalls ?? []) {
+        if (tc.toolName) names.add(tc.toolName)
+      }
+    }
+    return [...names].sort()
+  }, [data])
+
+  // Set of turn indices that pass the active filter
+  const isFilterActive =
+    filter.text.trim() !== '' || filter.toolName !== '' || filter.keyTurnsOnly
+  const matchedIndices = useMemo(() => {
+    if (!data) return new Set<number>()
+    const matched = new Set<number>()
+    data.turns.forEach((turn, i) => {
+      if (turnMatchesFilter(turn, i, filter, keyIndices)) matched.add(i)
+    })
+    return matched
+  }, [data, filter, keyIndices])
 
   // Viewport indicator position
   const viewportTopPct = (scrollInfo.top / scrollInfo.height) * 100
@@ -327,6 +358,46 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
         </div>
       )}
 
+      {/* Search / filter bar */}
+      <div className="playback-filter">
+        <input
+          type="text"
+          className="filter-text"
+          placeholder="ターンを検索（プロンプト・応答・ツール名）"
+          value={filter.text}
+          onChange={e => setFilter(f => ({ ...f, text: e.target.value }))}
+        />
+        <select
+          className="filter-tool"
+          value={filter.toolName}
+          onChange={e => setFilter(f => ({ ...f, toolName: e.target.value }))}
+        >
+          <option value="">すべてのツール</option>
+          {availableToolNames.map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+        <label className="filter-keyturns">
+          <input
+            type="checkbox"
+            checked={filter.keyTurnsOnly}
+            onChange={e => setFilter(f => ({ ...f, keyTurnsOnly: e.target.checked }))}
+          />
+          重要なターンのみ
+        </label>
+        {isFilterActive && (
+          <span className="filter-count">一致: {matchedIndices.size}</span>
+        )}
+        {isFilterActive && (
+          <button
+            className="filter-clear"
+            onClick={() => setFilter({ text: '', toolName: '', keyTurnsOnly: false })}
+          >
+            クリア
+          </button>
+        )}
+      </div>
+
       <div className="playback-body">
         {/* Minimap */}
         <div
@@ -378,20 +449,34 @@ export function SessionPlayback({ sessionId, onClose }: Props) {
 
         {/* Turn content */}
         <div ref={contentRef} className="playback-content">
-          {turns.map((turn, i) => (
-            <div
-              key={turn.turnIndex}
-              className={`playback-turn ${i === activeTurnIndex ? 'playback-turn--active' : ''}`}
-              ref={el => setTurnRef(i, el)}
-              onClick={() => setActiveTurnIndex(i)}
-            >
-              <PlaybackStep
-                turn={turn}
-                isActive={i === activeTurnIndex}
-                subagents={subagents}
-              />
-            </div>
-          ))}
+          {turns.map((turn, i) => {
+            // Non-matching turns are dimmed + collapsed in place but kept in the
+            // DOM so minimap/keyboard-nav indices stay valid.
+            const dimmed = isFilterActive && !matchedIndices.has(i)
+            return (
+              <div
+                key={turn.turnIndex}
+                className={`playback-turn ${i === activeTurnIndex ? 'playback-turn--active' : ''}${dimmed ? ' playback-turn--filtered' : ''}`}
+                ref={el => setTurnRef(i, el)}
+                onClick={() => setActiveTurnIndex(i)}
+              >
+                {dimmed ? (
+                  <div className="playback-turn-collapsed">
+                    <span className="collapsed-index">#{i + 1}</span>
+                    <span className="collapsed-prompt">
+                      {(turn.userPrompt ?? '').slice(0, 80) || '（プロンプトなし）'}
+                    </span>
+                  </div>
+                ) : (
+                  <PlaybackStep
+                    turn={turn}
+                    isActive={i === activeTurnIndex}
+                    subagents={subagents}
+                  />
+                )}
+              </div>
+            )
+          })}
         </div>
 
         <PlaybackSidePanel detail={data} />

--- a/src/components/playback/SubagentBranch.css
+++ b/src/components/playback/SubagentBranch.css
@@ -4,6 +4,33 @@
   padding-left: 12px;
 }
 
+/* Depth-based indentation + border so nested agents read as a tree.
+   Deeper levels indent further and shift border color. */
+.subagent-branch--depth-0 {
+  border-left-width: 3px;
+}
+
+.subagent-branch--depth-1 {
+  margin-left: 16px;
+  border-left-width: 2px;
+  border-left-color: var(--chart-4);
+}
+
+.subagent-branch--depth-2 {
+  margin-left: 24px;
+  border-left-width: 2px;
+  border-left-color: var(--chart-5);
+}
+
+.subagent-branch--depth-3,
+.subagent-branch--depth-4,
+.subagent-branch--depth-5,
+.subagent-branch--depth-6 {
+  margin-left: 32px;
+  border-left-width: 2px;
+  border-left-color: var(--chart-6);
+}
+
 .subagent-toggle {
   display: flex;
   align-items: center;

--- a/src/components/playback/SubagentBranch.tsx
+++ b/src/components/playback/SubagentBranch.tsx
@@ -4,12 +4,19 @@ import { PlaybackStep } from './PlaybackStep'
 import { usePlanMode } from './PlanModeContext'
 import './SubagentBranch.css'
 
+/** Max nesting depth rendered before collapsing further recursion. */
+const MAX_DEPTH = 6
+
 interface Props {
   agentId: string
   session: SubagentSession
+  /** Full subagent map, threaded through so nested agents render recursively. */
+  subagents: Record<string, SubagentSession>
+  /** Nesting depth (0 = top-level subagent). Drives indentation/border. */
+  depth?: number
 }
 
-export function SubagentBranch({ agentId, session }: Props) {
+export function SubagentBranch({ agentId, session, subagents, depth = 0 }: Props) {
   const [expanded, setExpanded] = useState(false)
   const isPlanMode = usePlanMode()
 
@@ -32,8 +39,12 @@ export function SubagentBranch({ agentId, session }: Props) {
     .map(([name, count]) => `${name}: ${count}`)
     .join(', ')
 
+  const depthClass = `subagent-branch--depth-${Math.min(depth, MAX_DEPTH)}`
+
   return (
-    <div className={`subagent-branch${isPlanMode ? ' subagent-branch--plan' : ''}`}>
+    <div
+      className={`subagent-branch ${depthClass}${isPlanMode ? ' subagent-branch--plan' : ''}`}
+    >
       <button
         className="subagent-toggle"
         onClick={() => setExpanded(prev => !prev)}
@@ -58,7 +69,8 @@ export function SubagentBranch({ agentId, session }: Props) {
               key={turn.turnIndex}
               turn={turn}
               isActive={false}
-              subagents={{}}
+              subagents={depth < MAX_DEPTH ? subagents : {}}
+              depth={depth + 1}
             />
           ))}
         </div>

--- a/src/components/playback/ToolCallBlock.css
+++ b/src/components/playback/ToolCallBlock.css
@@ -14,6 +14,10 @@
   border-bottom: 1px solid var(--border);
 }
 
+.tool-call-feedback {
+  margin-left: auto;
+}
+
 .tool-name-badge {
   display: inline-flex;
   align-items: center;

--- a/src/components/playback/ToolCallBlock.css
+++ b/src/components/playback/ToolCallBlock.css
@@ -179,6 +179,15 @@
   margin-top: 4px;
 }
 
+/* Collapsible input section */
+.tool-input-collapsible {
+  padding: 6px 10px;
+}
+
+.tool-input-collapsible .tool-input {
+  padding: 6px 0 0;
+}
+
 /* Result section */
 .tool-result {
   border-top: 1px solid var(--border);

--- a/src/components/playback/ToolCallBlock.tsx
+++ b/src/components/playback/ToolCallBlock.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { ToolCall, SubagentSession } from '../../types'
 import { SubagentBranch } from './SubagentBranch'
-import { getToolCategory, truncate } from './toolCallHelpers'
+import { countLines, getToolCategory, shouldCollapse, truncate } from './toolCallHelpers'
 import {
   AgentRenderer,
   AskUserQuestionRenderer,
@@ -31,22 +31,60 @@ interface Props {
   subagents: Record<string, SubagentSession>
 }
 
+/**
+ * Extract the primary "code body" of a tool input for collapse-detection,
+ * e.g. a Bash command (find/grep/ls -R bodies live here) or a search pattern.
+ * Returns null when the tool has no large code-like body.
+ */
+function extractInputBody(name: string, input: Record<string, unknown>): string | null {
+  const pick = (key: string): string | null =>
+    typeof input[key] === 'string' ? (input[key] as string) : null
+  switch (name) {
+    case 'Bash':
+      return pick('command')
+    case 'Grep':
+    case 'Glob':
+      return pick('pattern')
+    default:
+      return null
+  }
+}
+
 export function ToolCallBlock({ toolCall, subagents }: Props) {
   const name = toolCall.toolName ?? ''
   const input = toolCall.input ?? {}
   const result = toolCall.result ?? null
   const category = getToolCategory(name)
-  const isLongResult = typeof result === 'string' && result.length > 500
+  const resultStr =
+    result == null ? '' : typeof result === 'string' ? result : JSON.stringify(result)
+  const isLongResult = shouldCollapse(resultStr)
   const [resultOpen, setResultOpen] = useState(!isLongResult)
+
+  const inputBody = extractInputBody(name, input)
+  const isLongInput = inputBody != null && shouldCollapse(inputBody)
+  const [inputOpen, setInputOpen] = useState(!isLongInput)
 
   const subagentId = toolCall.subagentId ?? null
   const matchingSubagent = subagentId ? subagents[subagentId] : null
 
   const inputView = renderToolInput(name, input)
 
+  const renderInput = () => {
+    if (!isLongInput) return inputView
+    return (
+      <div className="tool-input-collapsible">
+        <button
+          className="tool-result-toggle"
+          onClick={() => setInputOpen(prev => !prev)}
+        >
+          入力を{inputOpen ? '非表示' : '表示'}（{countLines(inputBody!)}行）
+        </button>
+        {inputOpen && inputView}
+      </div>
+    )
+  }
+
   const renderResult = () => {
-    if (!result) return null
-    const resultStr = typeof result === 'string' ? result : JSON.stringify(result)
     if (!resultStr) return null
 
     return (
@@ -55,7 +93,7 @@ export function ToolCallBlock({ toolCall, subagents }: Props) {
           className="tool-result-toggle"
           onClick={() => setResultOpen(prev => !prev)}
         >
-          結果を{resultOpen ? '非表示' : '表示'}
+          結果を{resultOpen ? '非表示' : '表示'}（{countLines(resultStr)}行）
         </button>
         {resultOpen && (
           <pre className="tool-result-content">{truncate(resultStr, 2000)}</pre>
@@ -71,7 +109,7 @@ export function ToolCallBlock({ toolCall, subagents }: Props) {
           {name}
         </span>
       </div>
-      {inputView}
+      {renderInput()}
       {renderResult()}
       {(name === 'Agent' || name === 'Task') && matchingSubagent && (
         <SubagentBranch

--- a/src/components/playback/ToolCallBlock.tsx
+++ b/src/components/playback/ToolCallBlock.tsx
@@ -29,6 +29,8 @@ import './ToolCallBlock.css'
 interface Props {
   toolCall: ToolCall
   subagents: Record<string, SubagentSession>
+  /** Nesting depth, forwarded to recursively-rendered subagent branches. */
+  depth?: number
 }
 
 /**
@@ -50,7 +52,7 @@ function extractInputBody(name: string, input: Record<string, unknown>): string 
   }
 }
 
-export function ToolCallBlock({ toolCall, subagents }: Props) {
+export function ToolCallBlock({ toolCall, subagents, depth = 0 }: Props) {
   const name = toolCall.toolName ?? ''
   const input = toolCall.input ?? {}
   const result = toolCall.result ?? null
@@ -115,6 +117,8 @@ export function ToolCallBlock({ toolCall, subagents }: Props) {
         <SubagentBranch
           agentId={subagentId!}
           session={matchingSubagent}
+          subagents={subagents}
+          depth={depth}
         />
       )}
     </div>

--- a/src/components/playback/ToolCallBlock.tsx
+++ b/src/components/playback/ToolCallBlock.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { ToolCall, SubagentSession } from '../../types'
 import { SubagentBranch } from './SubagentBranch'
+import { FeedbackCluster } from './feedback/FeedbackCluster'
 import { countLines, getToolCategory, shouldCollapse, truncate } from './toolCallHelpers'
 import {
   AgentRenderer,
@@ -28,6 +29,8 @@ import './ToolCallBlock.css'
 
 interface Props {
   toolCall: ToolCall
+  /** Owning turn's numeric turnIndex, for block-level feedback keys. */
+  turnId: number
   subagents: Record<string, SubagentSession>
   /** Nesting depth, forwarded to recursively-rendered subagent branches. */
   depth?: number
@@ -52,7 +55,7 @@ function extractInputBody(name: string, input: Record<string, unknown>): string 
   }
 }
 
-export function ToolCallBlock({ toolCall, subagents, depth = 0 }: Props) {
+export function ToolCallBlock({ toolCall, turnId, subagents, depth = 0 }: Props) {
   const name = toolCall.toolName ?? ''
   const input = toolCall.input ?? {}
   const result = toolCall.result ?? null
@@ -110,6 +113,9 @@ export function ToolCallBlock({ toolCall, subagents, depth = 0 }: Props) {
         <span className={`tool-name-badge tool-name-badge--${category}`}>
           {name}
         </span>
+        <div className="tool-call-feedback">
+          <FeedbackCluster turnId={turnId} blockId={toolCall.toolUseId} />
+        </div>
       </div>
       {renderInput()}
       {renderResult()}

--- a/src/components/playback/ToolCallBlock.tsx
+++ b/src/components/playback/ToolCallBlock.tsx
@@ -31,6 +31,8 @@ interface Props {
   toolCall: ToolCall
   /** Owning turn's numeric turnIndex, for block-level feedback keys. */
   turnId: number
+  /** Index of this tool call within its turn; used as a stable fallback id. */
+  index: number
   subagents: Record<string, SubagentSession>
   /** Nesting depth, forwarded to recursively-rendered subagent branches. */
   depth?: number
@@ -55,9 +57,12 @@ function extractInputBody(name: string, input: Record<string, unknown>): string 
   }
 }
 
-export function ToolCallBlock({ toolCall, turnId, subagents, depth = 0 }: Props) {
+export function ToolCallBlock({ toolCall, turnId, index, subagents, depth = 0 }: Props) {
   const name = toolCall.toolName ?? ''
   const input = toolCall.input ?? {}
+  // toolUseId can be empty when the source block lacks an id; fall back to a
+  // per-turn-stable surrogate so distinct blocks get distinct feedback keys.
+  const blockId = toolCall.toolUseId || `idx-${index}`
   const result = toolCall.result ?? null
   const category = getToolCategory(name)
   const resultStr =
@@ -114,7 +119,7 @@ export function ToolCallBlock({ toolCall, turnId, subagents, depth = 0 }: Props)
           {name}
         </span>
         <div className="tool-call-feedback">
-          <FeedbackCluster turnId={turnId} blockId={toolCall.toolUseId} />
+          <FeedbackCluster turnId={turnId} blockId={blockId} />
         </div>
       </div>
       {renderInput()}

--- a/src/components/playback/__tests__/feedbackStore.test.ts
+++ b/src/components/playback/__tests__/feedbackStore.test.ts
@@ -196,6 +196,44 @@ describe('feedbackStore', () => {
     expect(loadSessionFeedback('s1', storage)).toEqual([])
   })
 
+  it('normalizes an entry missing tags/note/bookmarked on read', () => {
+    // Simulate an old/corrupted record lacking tags and note.
+    storage.setItem(
+      FEEDBACK_STORAGE_KEY,
+      JSON.stringify({ s1: [{ sessionId: 's1', turnId: 1 }] }),
+    )
+    const entry = getEntry('s1', 1, undefined, storage)
+    expect(entry).toMatchObject({ sessionId: 's1', turnId: 1, tags: [], note: '', bookmarked: false })
+    // removeTag must not throw on the (now normalized) entry.
+    expect(() => removeTag('s1', 1, undefined, 'whatever', storage)).not.toThrow()
+  })
+
+  it('drops entries failing the minimal shape check', () => {
+    storage.setItem(
+      FEEDBACK_STORAGE_KEY,
+      JSON.stringify({
+        s1: [
+          { sessionId: 's1', turnId: 1, note: 'good' },
+          { sessionId: 's1' }, // missing turnId
+          null,
+          'garbage',
+          { turnId: 2 }, // missing sessionId
+        ],
+      }),
+    )
+    const entries = loadSessionFeedback('s1', storage)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ turnId: 1, note: 'good' })
+  })
+
+  it('coerces a non-array tags field to an empty array', () => {
+    storage.setItem(
+      FEEDBACK_STORAGE_KEY,
+      JSON.stringify({ s1: [{ sessionId: 's1', turnId: 1, tags: 'oops', note: 'x' }] }),
+    )
+    expect(getEntry('s1', 1, undefined, storage)?.tags).toEqual([])
+  })
+
   it('persists across independent reads (serialized in storage)', () => {
     upsertEntry('s1', 5, 'blk', { note: 'persisted', tags: ['x'] } as Partial<FeedbackEntry>, storage)
     const raw = storage.getItem(FEEDBACK_STORAGE_KEY)

--- a/src/components/playback/__tests__/feedbackStore.test.ts
+++ b/src/components/playback/__tests__/feedbackStore.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  FEEDBACK_STORAGE_KEY,
+  addTag,
+  collectAllTags,
+  entryKey,
+  getEntry,
+  loadSessionFeedback,
+  removeEntry,
+  removeTag,
+  setNote,
+  toggleBookmark,
+  upsertEntry,
+} from '../feedback/feedbackStore'
+import type { FeedbackEntry } from '../../../types'
+
+/** Minimal in-memory Storage fake (no jsdom). */
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+  }
+}
+
+describe('entryKey', () => {
+  it('uses just the turnId for turn-level feedback', () => {
+    expect(entryKey(3)).toBe('3')
+  })
+
+  it('combines turnId and blockId for block-level feedback', () => {
+    expect(entryKey(3, 'tool-abc')).toBe('3:tool-abc')
+  })
+})
+
+describe('feedbackStore', () => {
+  let storage: Storage
+
+  beforeEach(() => {
+    storage = createMemoryStorage()
+  })
+
+  it('returns an empty list for an unknown session', () => {
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
+  })
+
+  it('upserts a new turn-level entry', () => {
+    upsertEntry('s1', 2, undefined, { note: 'hi' }, storage)
+    const entry = getEntry('s1', 2, undefined, storage)
+    expect(entry).toMatchObject({ sessionId: 's1', turnId: 2, note: 'hi', bookmarked: false, tags: [] })
+    expect(entry?.blockId).toBeUndefined()
+  })
+
+  it('upserts a block-level entry distinct from the turn-level one', () => {
+    upsertEntry('s1', 2, undefined, { note: 'turn' }, storage)
+    upsertEntry('s1', 2, 'blk', { note: 'block' }, storage)
+    expect(getEntry('s1', 2, undefined, storage)?.note).toBe('turn')
+    expect(getEntry('s1', 2, 'blk', storage)?.note).toBe('block')
+    expect(loadSessionFeedback('s1', storage)).toHaveLength(2)
+  })
+
+  it('merges fields on subsequent upserts of the same key', () => {
+    upsertEntry('s1', 1, undefined, { note: 'first' }, storage)
+    upsertEntry('s1', 1, undefined, { bookmarked: true }, storage)
+    const entry = getEntry('s1', 1, undefined, storage)
+    expect(entry).toMatchObject({ note: 'first', bookmarked: true })
+  })
+
+  it('toggles a bookmark on and off', () => {
+    expect(toggleBookmark('s1', 1, undefined, storage)).toBe(true)
+    expect(getEntry('s1', 1, undefined, storage)?.bookmarked).toBe(true)
+    expect(toggleBookmark('s1', 1, undefined, storage)).toBe(false)
+    expect(getEntry('s1', 1, undefined, storage)?.bookmarked).toBe(false)
+  })
+
+  it('adds tags and dedupes them', () => {
+    addTag('s1', 1, undefined, 'bug', storage)
+    addTag('s1', 1, undefined, 'bug', storage)
+    addTag('s1', 1, undefined, 'refactor', storage)
+    expect(getEntry('s1', 1, undefined, storage)?.tags).toEqual(['bug', 'refactor'])
+  })
+
+  it('ignores empty/whitespace tags', () => {
+    addTag('s1', 1, undefined, '   ', storage)
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+  })
+
+  it('removes a tag', () => {
+    addTag('s1', 1, undefined, 'bug', storage)
+    addTag('s1', 1, undefined, 'refactor', storage)
+    removeTag('s1', 1, undefined, 'bug', storage)
+    expect(getEntry('s1', 1, undefined, storage)?.tags).toEqual(['refactor'])
+  })
+
+  it('sets a note', () => {
+    setNote('s1', 1, undefined, 'remember this', storage)
+    expect(getEntry('s1', 1, undefined, storage)?.note).toBe('remember this')
+  })
+
+  it('removes an entry', () => {
+    upsertEntry('s1', 1, undefined, { note: 'x' }, storage)
+    removeEntry('s1', 1, undefined, storage)
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
+  })
+
+  it('collects all distinct tags across all sessions, sorted', () => {
+    addTag('s1', 1, undefined, 'zebra', storage)
+    addTag('s1', 2, undefined, 'apple', storage)
+    addTag('s2', 1, 'blk', 'apple', storage)
+    addTag('s2', 1, 'blk', 'mango', storage)
+    expect(collectAllTags(storage)).toEqual(['apple', 'mango', 'zebra'])
+  })
+
+  it('isolates feedback per session', () => {
+    upsertEntry('s1', 1, undefined, { note: 'one' }, storage)
+    upsertEntry('s2', 1, undefined, { note: 'two' }, storage)
+    expect(loadSessionFeedback('s1', storage)).toHaveLength(1)
+    expect(loadSessionFeedback('s2', storage)).toHaveLength(1)
+    expect(getEntry('s2', 1, undefined, storage)?.note).toBe('two')
+  })
+
+  it('recovers from malformed JSON in storage', () => {
+    storage.setItem(FEEDBACK_STORAGE_KEY, '{not valid json')
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
+    // and can still write afterwards
+    upsertEntry('s1', 1, undefined, { note: 'ok' }, storage)
+    expect(getEntry('s1', 1, undefined, storage)?.note).toBe('ok')
+  })
+
+  it('recovers when stored blob is not an object', () => {
+    storage.setItem(FEEDBACK_STORAGE_KEY, '42')
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
+  })
+
+  it('persists across independent reads (serialized in storage)', () => {
+    upsertEntry('s1', 5, 'blk', { note: 'persisted', tags: ['x'] } as Partial<FeedbackEntry>, storage)
+    const raw = storage.getItem(FEEDBACK_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    const reread = loadSessionFeedback('s1', storage)
+    expect(reread).toHaveLength(1)
+    expect(reread[0]).toMatchObject({ turnId: 5, blockId: 'blk', note: 'persisted', tags: ['x'] })
+  })
+})

--- a/src/components/playback/__tests__/feedbackStore.test.ts
+++ b/src/components/playback/__tests__/feedbackStore.test.ts
@@ -39,7 +39,14 @@ describe('entryKey', () => {
   })
 
   it('combines turnId and blockId for block-level feedback', () => {
-    expect(entryKey(3, 'tool-abc')).toBe('3:tool-abc')
+    expect(entryKey(3, 'tool-abc')).toBe('3:b:tool-abc')
+  })
+
+  it('keeps an empty-string blockId distinct from the turn-level key', () => {
+    // A tool_use block with a missing id yields blockId='' but must NOT collapse
+    // onto the turn-level key, otherwise it would overwrite turn feedback.
+    expect(entryKey(3, '')).toBe('3:b:')
+    expect(entryKey(3, '')).not.toBe(entryKey(3))
   })
 })
 
@@ -66,6 +73,22 @@ describe('feedbackStore', () => {
     upsertEntry('s1', 2, 'blk', { note: 'block' }, storage)
     expect(getEntry('s1', 2, undefined, storage)?.note).toBe('turn')
     expect(getEntry('s1', 2, 'blk', storage)?.note).toBe('block')
+    expect(loadSessionFeedback('s1', storage)).toHaveLength(2)
+  })
+
+  it('does not let an empty-blockId block overwrite turn-level feedback', () => {
+    upsertEntry('s1', 2, undefined, { note: 'turn' }, storage)
+    upsertEntry('s1', 2, '', { note: 'block-empty-id' }, storage)
+    expect(getEntry('s1', 2, undefined, storage)?.note).toBe('turn')
+    expect(getEntry('s1', 2, '', storage)?.note).toBe('block-empty-id')
+    expect(loadSessionFeedback('s1', storage)).toHaveLength(2)
+  })
+
+  it('keeps distinct surrogate blockIds from colliding', () => {
+    upsertEntry('s1', 2, 'idx-0', { note: 'first' }, storage)
+    upsertEntry('s1', 2, 'idx-1', { note: 'second' }, storage)
+    expect(getEntry('s1', 2, 'idx-0', storage)?.note).toBe('first')
+    expect(getEntry('s1', 2, 'idx-1', storage)?.note).toBe('second')
     expect(loadSessionFeedback('s1', storage)).toHaveLength(2)
   })
 

--- a/src/components/playback/__tests__/feedbackStore.test.ts
+++ b/src/components/playback/__tests__/feedbackStore.test.ts
@@ -99,11 +99,13 @@ describe('feedbackStore', () => {
     expect(entry).toMatchObject({ note: 'first', bookmarked: true })
   })
 
-  it('toggles a bookmark on and off', () => {
+  it('toggles a bookmark on and off, pruning the empty entry when off', () => {
     expect(toggleBookmark('s1', 1, undefined, storage)).toBe(true)
     expect(getEntry('s1', 1, undefined, storage)?.bookmarked).toBe(true)
     expect(toggleBookmark('s1', 1, undefined, storage)).toBe(false)
-    expect(getEntry('s1', 1, undefined, storage)?.bookmarked).toBe(false)
+    // Un-bookmarking leaves no bookmark/tags/note, so the entry is pruned.
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
   })
 
   it('adds tags and dedupes them', () => {
@@ -128,6 +130,34 @@ describe('feedbackStore', () => {
   it('sets a note', () => {
     setNote('s1', 1, undefined, 'remember this', storage)
     expect(getEntry('s1', 1, undefined, storage)?.note).toBe('remember this')
+  })
+
+  it('prunes the entry when a note is cleared back to blank', () => {
+    setNote('s1', 1, undefined, 'remember this', storage)
+    setNote('s1', 1, undefined, '', storage)
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+    expect(loadSessionFeedback('s1', storage)).toEqual([])
+  })
+
+  it('treats a whitespace-only note as empty and prunes it', () => {
+    setNote('s1', 1, undefined, '   ', storage)
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+  })
+
+  it('prunes the entry and drops the session bucket when the last tag is removed', () => {
+    addTag('s1', 1, undefined, 'bug', storage)
+    removeTag('s1', 1, undefined, 'bug', storage)
+    expect(getEntry('s1', 1, undefined, storage)).toBeNull()
+    // Session bucket is dropped entirely, not left as an empty array.
+    const raw = storage.getItem(FEEDBACK_STORAGE_KEY)
+    expect(raw ? Object.keys(JSON.parse(raw)) : []).not.toContain('s1')
+  })
+
+  it('keeps an entry that still has a bookmark when its note is cleared', () => {
+    toggleBookmark('s1', 1, undefined, storage)
+    setNote('s1', 1, undefined, 'temp', storage)
+    setNote('s1', 1, undefined, '', storage)
+    expect(getEntry('s1', 1, undefined, storage)?.bookmarked).toBe(true)
   })
 
   it('removes an entry', () => {

--- a/src/components/playback/__tests__/toolCallHelpers.test.ts
+++ b/src/components/playback/__tests__/toolCallHelpers.test.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect } from 'vitest'
+import type { ConversationTurn } from '../../../types'
 import {
   countLines,
   getToolCategory,
   parseMcpToolName,
   pickKeyInputArgs,
+  selectKeyMoments,
   shouldCollapse,
   summarizeValue,
   truncate,
 } from '../toolCallHelpers'
+
+function makeTurn(partial: Partial<ConversationTurn> & { turnIndex: number }): ConversationTurn {
+  return {
+    timestamp: '2026-01-01T00:00:00Z',
+    userPrompt: '',
+    assistantThinking: [],
+    assistantTexts: [],
+    toolCalls: [],
+    ...partial,
+  }
+}
 
 describe('countLines', () => {
   it('returns 0 for an empty string', () => {
@@ -56,6 +69,66 @@ describe('shouldCollapse', () => {
 
   it('does not collapse content of exactly 500 chars on few lines', () => {
     expect(shouldCollapse('a'.repeat(500))).toBe(false)
+  })
+})
+
+describe('selectKeyMoments', () => {
+  it('returns empty for no turns', () => {
+    expect(selectKeyMoments([])).toEqual([])
+  })
+
+  it('always includes the final turn', () => {
+    const turns = [
+      makeTurn({ turnIndex: 0, userPrompt: 'hi' }),
+      makeTurn({ turnIndex: 1, userPrompt: 'bye' }),
+    ]
+    const moments = selectKeyMoments(turns)
+    expect(moments.some(m => m.index === 1)).toBe(true)
+    expect(moments[moments.length - 1].kind).toBe('final')
+  })
+
+  it('flags agent turns', () => {
+    const turns = [
+      makeTurn({ turnIndex: 0, toolCalls: [{ toolUseId: 't', toolName: 'Agent', input: {} }] }),
+      makeTurn({ turnIndex: 1 }),
+    ]
+    const moments = selectKeyMoments(turns)
+    const m = moments.find(x => x.index === 0)
+    expect(m?.kind).toBe('agent')
+  })
+
+  it('flags plan/task turns', () => {
+    const turns = [
+      makeTurn({ turnIndex: 0, toolCalls: [{ toolUseId: 't', toolName: 'EnterPlanMode', input: {} }] }),
+      makeTurn({ turnIndex: 1, toolCalls: [{ toolUseId: 't', toolName: 'TaskCreate', input: {} }] }),
+      makeTurn({ turnIndex: 2 }),
+    ]
+    const moments = selectKeyMoments(turns)
+    expect(moments.find(x => x.index === 0)?.kind).toBe('plan')
+    expect(moments.find(x => x.index === 1)?.kind).toBe('plan')
+  })
+
+  it('includes long/substantive user prompts but not short ones', () => {
+    const longPrompt = 'a'.repeat(100)
+    const turns = [
+      makeTurn({ turnIndex: 0, userPrompt: 'short' }),
+      makeTurn({ turnIndex: 1, userPrompt: longPrompt }),
+      makeTurn({ turnIndex: 2 }),
+    ]
+    const moments = selectKeyMoments(turns)
+    expect(moments.some(m => m.index === 0)).toBe(false)
+    expect(moments.find(m => m.index === 1)?.kind).toBe('prompt')
+  })
+
+  it('returns moments sorted by index without duplicates', () => {
+    const turns = [
+      makeTurn({ turnIndex: 0, toolCalls: [{ toolUseId: 't', toolName: 'Agent', input: {} }], userPrompt: 'x'.repeat(100) }),
+      makeTurn({ turnIndex: 1 }),
+    ]
+    const moments = selectKeyMoments(turns)
+    const indices = moments.map(m => m.index)
+    expect(indices).toEqual([...indices].sort((a, b) => a - b))
+    expect(new Set(indices).size).toBe(indices.length)
   })
 })
 

--- a/src/components/playback/__tests__/toolCallHelpers.test.ts
+++ b/src/components/playback/__tests__/toolCallHelpers.test.ts
@@ -1,11 +1,63 @@
 import { describe, it, expect } from 'vitest'
 import {
+  countLines,
   getToolCategory,
   parseMcpToolName,
   pickKeyInputArgs,
+  shouldCollapse,
   summarizeValue,
   truncate,
 } from '../toolCallHelpers'
+
+describe('countLines', () => {
+  it('returns 0 for an empty string', () => {
+    expect(countLines('')).toBe(0)
+  })
+
+  it('counts a single line with no trailing newline', () => {
+    expect(countLines('hello')).toBe(1)
+  })
+
+  it('counts lines separated by \\n', () => {
+    expect(countLines('a\nb\nc')).toBe(3)
+  })
+
+  it('does not count a trailing newline as an extra empty line', () => {
+    expect(countLines('a\nb\n')).toBe(2)
+  })
+
+  it('handles CRLF line endings', () => {
+    expect(countLines('a\r\nb\r\nc')).toBe(3)
+  })
+
+  it('counts blank interior lines', () => {
+    expect(countLines('a\n\nb')).toBe(3)
+  })
+})
+
+describe('shouldCollapse', () => {
+  it('does not collapse short single-line content', () => {
+    expect(shouldCollapse('hello world')).toBe(false)
+  })
+
+  it('collapses content with more than 15 lines', () => {
+    const sixteen = Array.from({ length: 16 }, (_, i) => `line ${i}`).join('\n')
+    expect(shouldCollapse(sixteen)).toBe(true)
+  })
+
+  it('does not collapse content with exactly 15 lines under the char limit', () => {
+    const fifteen = Array.from({ length: 15 }, () => 'x').join('\n')
+    expect(shouldCollapse(fifteen)).toBe(false)
+  })
+
+  it('collapses content longer than 500 chars even on a single line', () => {
+    expect(shouldCollapse('a'.repeat(501))).toBe(true)
+  })
+
+  it('does not collapse content of exactly 500 chars on few lines', () => {
+    expect(shouldCollapse('a'.repeat(500))).toBe(false)
+  })
+})
 
 describe('getToolCategory', () => {
   it('classifies the existing 7 tool surface', () => {

--- a/src/components/playback/__tests__/toolCallHelpers.test.ts
+++ b/src/components/playback/__tests__/toolCallHelpers.test.ts
@@ -9,7 +9,9 @@ import {
   shouldCollapse,
   summarizeValue,
   truncate,
+  turnMatchesFilter,
 } from '../toolCallHelpers'
+import type { PlaybackFilter } from '../toolCallHelpers'
 
 function makeTurn(partial: Partial<ConversationTurn> & { turnIndex: number }): ConversationTurn {
   return {
@@ -129,6 +131,69 @@ describe('selectKeyMoments', () => {
     const indices = moments.map(m => m.index)
     expect(indices).toEqual([...indices].sort((a, b) => a - b))
     expect(new Set(indices).size).toBe(indices.length)
+  })
+})
+
+describe('turnMatchesFilter', () => {
+  const empty: PlaybackFilter = { text: '', toolName: '', keyTurnsOnly: false }
+  const keyIndices = new Set([2])
+
+  it('matches everything when the filter is empty', () => {
+    const turn = makeTurn({ turnIndex: 0, userPrompt: 'anything' })
+    expect(turnMatchesFilter(turn, 0, empty, keyIndices)).toBe(true)
+  })
+
+  it('matches free text against the user prompt (case-insensitive)', () => {
+    const turn = makeTurn({ turnIndex: 0, userPrompt: 'Fix the BUG in parser' })
+    expect(turnMatchesFilter(turn, 0, { ...empty, text: 'bug' }, keyIndices)).toBe(true)
+    expect(turnMatchesFilter(turn, 0, { ...empty, text: 'feature' }, keyIndices)).toBe(false)
+  })
+
+  it('matches free text against assistant texts', () => {
+    const turn = makeTurn({ turnIndex: 0, assistantTexts: ['Here is the diff'] })
+    expect(turnMatchesFilter(turn, 0, { ...empty, text: 'diff' }, keyIndices)).toBe(true)
+  })
+
+  it('matches free text against tool names', () => {
+    const turn = makeTurn({
+      turnIndex: 0,
+      toolCalls: [{ toolUseId: 't', toolName: 'Bash', input: {} }],
+    })
+    expect(turnMatchesFilter(turn, 0, { ...empty, text: 'bash' }, keyIndices)).toBe(true)
+  })
+
+  it('filters by exact tool name', () => {
+    const turn = makeTurn({
+      turnIndex: 0,
+      toolCalls: [{ toolUseId: 't', toolName: 'Edit', input: {} }],
+    })
+    expect(turnMatchesFilter(turn, 0, { ...empty, toolName: 'Edit' }, keyIndices)).toBe(true)
+    expect(turnMatchesFilter(turn, 0, { ...empty, toolName: 'Bash' }, keyIndices)).toBe(false)
+  })
+
+  it('restricts to key turns when keyTurnsOnly is set', () => {
+    const turn = makeTurn({ turnIndex: 2 })
+    expect(turnMatchesFilter(turn, 2, { ...empty, keyTurnsOnly: true }, keyIndices)).toBe(true)
+    expect(turnMatchesFilter(turn, 1, { ...empty, keyTurnsOnly: true }, keyIndices)).toBe(false)
+  })
+
+  it('requires all active conditions (AND semantics)', () => {
+    const turn = makeTurn({
+      turnIndex: 2,
+      userPrompt: 'fix bug',
+      toolCalls: [{ toolUseId: 't', toolName: 'Edit', input: {} }],
+    })
+    const filter: PlaybackFilter = { text: 'bug', toolName: 'Edit', keyTurnsOnly: true }
+    expect(turnMatchesFilter(turn, 2, filter, keyIndices)).toBe(true)
+    // text fails
+    expect(turnMatchesFilter(turn, 2, { ...filter, text: 'nope' }, keyIndices)).toBe(false)
+    // tool fails
+    expect(turnMatchesFilter(turn, 2, { ...filter, toolName: 'Bash' }, keyIndices)).toBe(false)
+  })
+
+  it('ignores whitespace-only text filters', () => {
+    const turn = makeTurn({ turnIndex: 0, userPrompt: 'hi' })
+    expect(turnMatchesFilter(turn, 0, { ...empty, text: '   ' }, keyIndices)).toBe(true)
   })
 })
 

--- a/src/components/playback/feedback/FeedbackCluster.css
+++ b/src/components/playback/feedback/FeedbackCluster.css
@@ -1,0 +1,133 @@
+.feedback-cluster {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.feedback-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 5px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: none;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s, border-color 0.15s, background-color 0.15s;
+}
+
+.feedback-btn:hover {
+  opacity: 1;
+  background-color: var(--bg-tertiary);
+}
+
+.feedback-btn--has,
+.feedback-btn--open {
+  opacity: 1;
+}
+
+.feedback-btn--open {
+  border-color: var(--border);
+  background-color: var(--bg-tertiary);
+}
+
+/* Active bookmark uses the interactive accent color */
+.feedback-btn--bookmark.feedback-btn--active {
+  opacity: 1;
+  border-color: var(--accent);
+  background-color: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.feedback-count {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.feedback-popover {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 10;
+  margin-top: 4px;
+  min-width: 220px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background-color: var(--bg-secondary);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+}
+
+.feedback-note {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.feedback-note:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ─── TagInput ─────────────────────────────────────────────────────────── */
+.tag-input {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tag-input-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 4px 1px 7px;
+  border-radius: 999px;
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.tag-chip-remove {
+  border: none;
+  background: none;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.tag-chip-remove:hover {
+  color: var(--danger);
+}
+
+.tag-input-field {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.tag-input-field:focus {
+  outline: none;
+  border-color: var(--accent);
+}

--- a/src/components/playback/feedback/FeedbackCluster.tsx
+++ b/src/components/playback/feedback/FeedbackCluster.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useFeedback } from './FeedbackContext'
 import { TagInput } from './TagInput'
 import './FeedbackCluster.css'
@@ -70,15 +70,64 @@ export function FeedbackCluster({ turnId, blockId }: Props) {
 
       {noteOpen && (
         <div className="feedback-popover">
-          <textarea
-            className="feedback-note"
-            placeholder="メモを追加"
+          <NoteEditor
             value={note}
-            onChange={e => fb.setNote(turnId, blockId, e.target.value)}
-            rows={3}
+            onCommit={next => fb.setNote(turnId, blockId, next)}
           />
         </div>
       )}
     </div>
+  )
+}
+
+interface NoteEditorProps {
+  /** Committed note from the store. */
+  value: string
+  /** Persist the draft to the store. Called on blur and on unmount. */
+  onCommit: (note: string) => void
+}
+
+/**
+ * Note textarea that keeps edits in local state and only commits to the store
+ * on blur or unmount, instead of on every keystroke. This avoids a full
+ * localStorage write + version bump + tree re-render per character typed.
+ */
+function NoteEditor({ value, onCommit }: NoteEditorProps) {
+  const [draft, setDraft] = useState(value)
+
+  // Re-seed when the committed value changes externally (e.g. a different
+  // entry is selected while the editor stays mounted).
+  useEffect(() => {
+    setDraft(value)
+  }, [value])
+
+  // Keep the latest draft/value in a ref so the unmount-commit effect can read
+  // them without re-running (and thus committing) on every keystroke. The ref
+  // is updated in an effect (never during render) per react-hooks/refs.
+  const latest = useRef({ draft, value, onCommit })
+  useEffect(() => {
+    latest.current = { draft, value, onCommit }
+  })
+
+  useEffect(() => {
+    return () => {
+      const { draft: d, value: v, onCommit: commit } = latest.current
+      if (d !== v) commit(d)
+    }
+  }, [])
+
+  const commit = () => {
+    if (draft !== value) onCommit(draft)
+  }
+
+  return (
+    <textarea
+      className="feedback-note"
+      placeholder="メモを追加"
+      value={draft}
+      onChange={e => setDraft(e.target.value)}
+      onBlur={commit}
+      rows={3}
+    />
   )
 }

--- a/src/components/playback/feedback/FeedbackCluster.tsx
+++ b/src/components/playback/feedback/FeedbackCluster.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { useFeedback } from './FeedbackContext'
+import { TagInput } from './TagInput'
+import './FeedbackCluster.css'
+
+interface Props {
+  turnId: number
+  /** Tool-call block id (toolUseId) for block-level feedback; absent = turn-level. */
+  blockId?: string
+}
+
+/**
+ * Icon cluster for bookmark / tags / note feedback on a turn or tool-call
+ * block. Reads and writes via FeedbackContext. Tags and note open inline
+ * popovers using the expand/collapse convention (useState + conditional
+ * render, no animation).
+ */
+export function FeedbackCluster({ turnId, blockId }: Props) {
+  const fb = useFeedback()
+  const entry = fb.getEntry(turnId, blockId)
+  const bookmarked = entry?.bookmarked ?? false
+  const tags = entry?.tags ?? []
+  const note = entry?.note ?? ''
+
+  const [tagsOpen, setTagsOpen] = useState(false)
+  const [noteOpen, setNoteOpen] = useState(false)
+
+  const stop = (e: React.MouseEvent) => e.stopPropagation()
+
+  return (
+    <div className="feedback-cluster" onClick={stop}>
+      <button
+        className={`feedback-btn feedback-btn--bookmark ${bookmarked ? 'feedback-btn--active' : ''}`}
+        title={bookmarked ? 'ブックマークを解除' : 'ブックマーク'}
+        aria-pressed={bookmarked}
+        onClick={() => fb.toggleBookmark(turnId, blockId)}
+      >
+        {'⭐'}
+      </button>
+
+      <button
+        className={`feedback-btn ${tags.length > 0 ? 'feedback-btn--has' : ''} ${tagsOpen ? 'feedback-btn--open' : ''}`}
+        title="タグ"
+        aria-expanded={tagsOpen}
+        onClick={() => setTagsOpen(o => !o)}
+      >
+        {'🏷'}
+        {tags.length > 0 && <span className="feedback-count">{tags.length}</span>}
+      </button>
+
+      <button
+        className={`feedback-btn ${note ? 'feedback-btn--has' : ''} ${noteOpen ? 'feedback-btn--open' : ''}`}
+        title="メモ"
+        aria-expanded={noteOpen}
+        onClick={() => setNoteOpen(o => !o)}
+      >
+        {'📝'}
+      </button>
+
+      {tagsOpen && (
+        <div className="feedback-popover">
+          <TagInput
+            tags={tags}
+            suggestions={fb.allTags}
+            onAdd={tag => fb.addTag(turnId, blockId, tag)}
+            onRemove={tag => fb.removeTag(turnId, blockId, tag)}
+          />
+        </div>
+      )}
+
+      {noteOpen && (
+        <div className="feedback-popover">
+          <textarea
+            className="feedback-note"
+            placeholder="メモを追加"
+            value={note}
+            onChange={e => fb.setNote(turnId, blockId, e.target.value)}
+            rows={3}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/playback/feedback/FeedbackCluster.tsx
+++ b/src/components/playback/feedback/FeedbackCluster.tsx
@@ -96,10 +96,14 @@ function NoteEditor({ value, onCommit }: NoteEditorProps) {
   const [draft, setDraft] = useState(value)
 
   // Re-seed when the committed value changes externally (e.g. a different
-  // entry is selected while the editor stays mounted).
-  useEffect(() => {
+  // entry is selected while the editor stays mounted). Done during render via
+  // a previous-value tracker rather than an effect, per React's "adjusting
+  // state on prop change" guidance — this avoids a setState-in-effect.
+  const [seededValue, setSeededValue] = useState(value)
+  if (value !== seededValue) {
+    setSeededValue(value)
     setDraft(value)
-  }, [value])
+  }
 
   // Keep the latest draft/value in a ref so the unmount-commit effect can read
   // them without re-running (and thus committing) on every keystroke. The ref

--- a/src/components/playback/feedback/FeedbackContext.ts
+++ b/src/components/playback/feedback/FeedbackContext.ts
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react'
+import type { FeedbackEntry } from '../../../types'
+
+/**
+ * Feedback API exposed to playback components, scoped to the current session.
+ * Mirrors the PlanModeContext pattern to avoid prop-drilling.
+ */
+export interface FeedbackContextValue {
+  /** Look up the entry for a turn (blockId omitted) or block. */
+  getEntry: (turnId: number, blockId?: string) => FeedbackEntry | null
+  toggleBookmark: (turnId: number, blockId?: string) => void
+  addTag: (turnId: number, blockId: string | undefined, tag: string) => void
+  removeTag: (turnId: number, blockId: string | undefined, tag: string) => void
+  setNote: (turnId: number, blockId: string | undefined, note: string) => void
+  /** All distinct tags across sessions, for autocomplete. */
+  allTags: string[]
+}
+
+const noop = () => {}
+
+export const FeedbackContext = createContext<FeedbackContextValue>({
+  getEntry: () => null,
+  toggleBookmark: noop,
+  addTag: noop,
+  removeTag: noop,
+  setNote: noop,
+  allTags: [],
+})
+
+export function useFeedback(): FeedbackContextValue {
+  return useContext(FeedbackContext)
+}

--- a/src/components/playback/feedback/TagInput.tsx
+++ b/src/components/playback/feedback/TagInput.tsx
@@ -1,0 +1,65 @@
+import { useId, useState } from 'react'
+
+interface Props {
+  /** Existing tags on the entry. */
+  tags: string[]
+  /** Tag suggestions for autocomplete (all known tags). */
+  suggestions: string[]
+  onAdd: (tag: string) => void
+  onRemove: (tag: string) => void
+}
+
+/**
+ * Controlled tag editor with native <datalist> autocomplete. Submits the
+ * current value on Enter, deduping is handled upstream by the store.
+ */
+export function TagInput({ tags, suggestions, onAdd, onRemove }: Props) {
+  const [value, setValue] = useState('')
+  const listId = useId()
+
+  const commit = () => {
+    const clean = value.trim()
+    if (!clean) return
+    onAdd(clean)
+    setValue('')
+  }
+
+  return (
+    <div className="tag-input">
+      <div className="tag-input-chips">
+        {tags.map(tag => (
+          <span key={tag} className="tag-chip">
+            {tag}
+            <button
+              className="tag-chip-remove"
+              onClick={() => onRemove(tag)}
+              aria-label={`タグ「${tag}」を削除`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <input
+        className="tag-input-field"
+        type="text"
+        list={listId}
+        placeholder="タグを追加"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            commit()
+          }
+        }}
+        onBlur={commit}
+      />
+      <datalist id={listId}>
+        {suggestions.map(s => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+    </div>
+  )
+}

--- a/src/components/playback/feedback/feedbackStore.ts
+++ b/src/components/playback/feedback/feedbackStore.ts
@@ -1,0 +1,210 @@
+/**
+ * Pure, framework-free store for playback feedback (bookmarks / tags / notes).
+ *
+ * Backed by a single localStorage blob under `crune.feedback.v1`, shaped
+ * `Record<sessionId, FeedbackEntry[]>`. The backing `Storage` is injectable so
+ * the logic can be unit-tested with an in-memory fake (no jsdom). Malformed
+ * JSON is recovered from gracefully (treated as empty).
+ *
+ * Entry identity within a session:
+ *   - turn-level:  `${turnId}`
+ *   - block-level: `${turnId}:${blockId}`
+ */
+import type { FeedbackEntry } from '../../../types'
+
+export const FEEDBACK_STORAGE_KEY = 'crune.feedback.v1'
+
+type FeedbackBlob = Record<string, FeedbackEntry[]>
+
+function defaultStorage(): Storage | null {
+  return typeof window !== 'undefined' ? window.localStorage : null
+}
+
+/** Compute the within-session identity key for an entry. */
+export function entryKey(turnId: number, blockId?: string): string {
+  return blockId != null && blockId !== '' ? `${turnId}:${blockId}` : `${turnId}`
+}
+
+function entryKeyOf(entry: FeedbackEntry): string {
+  return entryKey(entry.turnId, entry.blockId)
+}
+
+function readBlob(storage: Storage | null): FeedbackBlob {
+  if (!storage) return {}
+  const raw = storage.getItem(FEEDBACK_STORAGE_KEY)
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as FeedbackBlob
+    }
+    return {}
+  } catch {
+    return {}
+  }
+}
+
+function writeBlob(storage: Storage | null, blob: FeedbackBlob): void {
+  if (!storage) return
+  storage.setItem(FEEDBACK_STORAGE_KEY, JSON.stringify(blob))
+}
+
+/** All feedback entries for a session (empty if none / unknown session). */
+export function loadSessionFeedback(
+  sessionId: string,
+  storage: Storage | null = defaultStorage(),
+): FeedbackEntry[] {
+  const blob = readBlob(storage)
+  return blob[sessionId] ?? []
+}
+
+/** A single entry by identity, or null if not present. */
+export function getEntry(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  storage: Storage | null = defaultStorage(),
+): FeedbackEntry | null {
+  const key = entryKey(turnId, blockId)
+  const entries = loadSessionFeedback(sessionId, storage)
+  return entries.find(e => entryKeyOf(e) === key) ?? null
+}
+
+/**
+ * Create or merge-update an entry. Missing fields default to a blank entry,
+ * and `patch` fields override. Returns the resulting entry.
+ */
+export function upsertEntry(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  patch: Partial<FeedbackEntry>,
+  storage: Storage | null = defaultStorage(),
+): FeedbackEntry {
+  const blob = readBlob(storage)
+  const entries = blob[sessionId] ? [...blob[sessionId]] : []
+  const key = entryKey(turnId, blockId)
+  const idx = entries.findIndex(e => entryKeyOf(e) === key)
+
+  const base: FeedbackEntry =
+    idx >= 0
+      ? entries[idx]
+      : {
+          sessionId,
+          turnId,
+          ...(blockId != null && blockId !== '' ? { blockId } : {}),
+          bookmarked: false,
+          tags: [],
+          note: '',
+        }
+
+  const next: FeedbackEntry = {
+    ...base,
+    ...patch,
+    // identity fields are authoritative
+    sessionId,
+    turnId,
+  }
+  if (blockId != null && blockId !== '') {
+    next.blockId = blockId
+  } else {
+    delete next.blockId
+  }
+
+  if (idx >= 0) {
+    entries[idx] = next
+  } else {
+    entries.push(next)
+  }
+  blob[sessionId] = entries
+  writeBlob(storage, blob)
+  return next
+}
+
+/** Delete an entry entirely. */
+export function removeEntry(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  storage: Storage | null = defaultStorage(),
+): void {
+  const blob = readBlob(storage)
+  const entries = blob[sessionId]
+  if (!entries) return
+  const key = entryKey(turnId, blockId)
+  const next = entries.filter(e => entryKeyOf(e) !== key)
+  if (next.length === 0) {
+    delete blob[sessionId]
+  } else {
+    blob[sessionId] = next
+  }
+  writeBlob(storage, blob)
+}
+
+/** Flip the bookmark flag. Returns the new bookmarked state. */
+export function toggleBookmark(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  storage: Storage | null = defaultStorage(),
+): boolean {
+  const current = getEntry(sessionId, turnId, blockId, storage)
+  const next = !(current?.bookmarked ?? false)
+  upsertEntry(sessionId, turnId, blockId, { bookmarked: next }, storage)
+  return next
+}
+
+/** Add a tag (trimmed, deduped). No-op for empty/whitespace tags. */
+export function addTag(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  tag: string,
+  storage: Storage | null = defaultStorage(),
+): void {
+  const clean = tag.trim()
+  if (!clean) return
+  const current = getEntry(sessionId, turnId, blockId, storage)
+  const tags = current?.tags ?? []
+  if (tags.includes(clean)) return
+  upsertEntry(sessionId, turnId, blockId, { tags: [...tags, clean] }, storage)
+}
+
+/** Remove a tag if present. */
+export function removeTag(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  tag: string,
+  storage: Storage | null = defaultStorage(),
+): void {
+  const current = getEntry(sessionId, turnId, blockId, storage)
+  if (!current) return
+  const tags = current.tags.filter(t => t !== tag)
+  upsertEntry(sessionId, turnId, blockId, { tags }, storage)
+}
+
+/** Set the freeform note. */
+export function setNote(
+  sessionId: string,
+  turnId: number,
+  blockId: string | undefined,
+  note: string,
+  storage: Storage | null = defaultStorage(),
+): void {
+  upsertEntry(sessionId, turnId, blockId, { note }, storage)
+}
+
+/** Distinct tags across all sessions, sorted ascending. */
+export function collectAllTags(
+  storage: Storage | null = defaultStorage(),
+): string[] {
+  const blob = readBlob(storage)
+  const tags = new Set<string>()
+  for (const entries of Object.values(blob)) {
+    for (const entry of entries) {
+      for (const tag of entry.tags ?? []) tags.add(tag)
+    }
+  }
+  return [...tags].sort()
+}

--- a/src/components/playback/feedback/feedbackStore.ts
+++ b/src/components/playback/feedback/feedbackStore.ts
@@ -42,16 +42,43 @@ function isEmptyEntry(entry: FeedbackEntry): boolean {
   return !entry.bookmarked && (entry.tags?.length ?? 0) === 0 && (entry.note ?? '').trim() === ''
 }
 
+/**
+ * Coerce a raw stored value into a well-formed FeedbackEntry, or null if it
+ * fails the minimal shape check (must carry a string sessionId and numeric
+ * turnId). Tolerant of old/corrupted records missing `tags`/`note`/`bookmarked`
+ * so downstream code (removeTag, render) never throws on a malformed entry.
+ */
+function normalizeEntry(raw: unknown): FeedbackEntry | null {
+  if (!raw || typeof raw !== 'object') return null
+  const e = raw as Record<string, unknown>
+  if (typeof e.sessionId !== 'string' || typeof e.turnId !== 'number') return null
+  const entry: FeedbackEntry = {
+    sessionId: e.sessionId,
+    turnId: e.turnId,
+    bookmarked: !!e.bookmarked,
+    tags: Array.isArray(e.tags) ? e.tags.filter((t): t is string => typeof t === 'string') : [],
+    note: typeof e.note === 'string' ? e.note : '',
+  }
+  if (typeof e.blockId === 'string') entry.blockId = e.blockId
+  return entry
+}
+
 function readBlob(storage: Storage | null): FeedbackBlob {
   if (!storage) return {}
   const raw = storage.getItem(FEEDBACK_STORAGE_KEY)
   if (!raw) return {}
   try {
     const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as FeedbackBlob
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const blob: FeedbackBlob = {}
+    for (const [sessionId, entries] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(entries)) continue
+      const normalized = entries
+        .map(normalizeEntry)
+        .filter((e): e is FeedbackEntry => e !== null)
+      if (normalized.length > 0) blob[sessionId] = normalized
     }
-    return {}
+    return blob
   } catch {
     return {}
   }

--- a/src/components/playback/feedback/feedbackStore.ts
+++ b/src/components/playback/feedback/feedbackStore.ts
@@ -8,7 +8,11 @@
  *
  * Entry identity within a session:
  *   - turn-level:  `${turnId}`
- *   - block-level: `${turnId}:${blockId}`
+ *   - block-level: `${turnId}:b:${blockId}`
+ *
+ * The `:b:` marker keeps block-level keys distinct from the turn-level key even
+ * when `blockId` is an empty string, so a tool_use block with a missing id can
+ * never collide with (and overwrite) its turn-level feedback.
  */
 import type { FeedbackEntry } from '../../../types'
 
@@ -22,7 +26,7 @@ function defaultStorage(): Storage | null {
 
 /** Compute the within-session identity key for an entry. */
 export function entryKey(turnId: number, blockId?: string): string {
-  return blockId != null && blockId !== '' ? `${turnId}:${blockId}` : `${turnId}`
+  return blockId != null ? `${turnId}:b:${blockId}` : `${turnId}`
 }
 
 function entryKeyOf(entry: FeedbackEntry): string {
@@ -92,7 +96,7 @@ export function upsertEntry(
       : {
           sessionId,
           turnId,
-          ...(blockId != null && blockId !== '' ? { blockId } : {}),
+          ...(blockId != null ? { blockId } : {}),
           bookmarked: false,
           tags: [],
           note: '',
@@ -105,7 +109,7 @@ export function upsertEntry(
     sessionId,
     turnId,
   }
-  if (blockId != null && blockId !== '') {
+  if (blockId != null) {
     next.blockId = blockId
   } else {
     delete next.blockId

--- a/src/components/playback/feedback/feedbackStore.ts
+++ b/src/components/playback/feedback/feedbackStore.ts
@@ -33,6 +33,15 @@ function entryKeyOf(entry: FeedbackEntry): string {
   return entryKey(entry.turnId, entry.blockId)
 }
 
+/**
+ * True when an entry carries no signal: not bookmarked, no tags, blank note.
+ * Such entries are pruned rather than persisted so clearing a note / removing
+ * the last tag / un-bookmarking does not leave dangling blank records behind.
+ */
+function isEmptyEntry(entry: FeedbackEntry): boolean {
+  return !entry.bookmarked && (entry.tags?.length ?? 0) === 0 && (entry.note ?? '').trim() === ''
+}
+
 function readBlob(storage: Storage | null): FeedbackBlob {
   if (!storage) return {}
   const raw = storage.getItem(FEEDBACK_STORAGE_KEY)
@@ -113,6 +122,21 @@ export function upsertEntry(
     next.blockId = blockId
   } else {
     delete next.blockId
+  }
+
+  // Prune rather than persist entries that carry no signal, and drop the
+  // session bucket entirely once it has no entries left.
+  if (isEmptyEntry(next)) {
+    if (idx >= 0) {
+      entries.splice(idx, 1)
+    }
+    if (entries.length === 0) {
+      delete blob[sessionId]
+    } else {
+      blob[sessionId] = entries
+    }
+    writeBlob(storage, blob)
+    return next
   }
 
   if (idx >= 0) {

--- a/src/components/playback/toolCallHelpers.ts
+++ b/src/components/playback/toolCallHelpers.ts
@@ -91,6 +91,39 @@ export function parseMcpToolName(name: string): McpToolParts | null {
 }
 
 /**
+ * Count the number of lines in a string.
+ *
+ * An empty string has 0 lines. A trailing newline does not add a phantom
+ * empty line (so `"a\nb\n"` is 2 lines, not 3). CRLF endings are normalized.
+ */
+export function countLines(str: string): number {
+  if (str.length === 0) return 0
+  const normalized = str.replace(/\r\n/g, '\n')
+  const withoutTrailing = normalized.endsWith('\n')
+    ? normalized.slice(0, -1)
+    : normalized
+  if (withoutTrailing.length === 0) return 1
+  return withoutTrailing.split('\n').length
+}
+
+/** Thresholds for collapsing long tool input/output content. */
+export const COLLAPSE_LINE_THRESHOLD = 15
+export const COLLAPSE_CHAR_THRESHOLD = 500
+
+/**
+ * Decide whether a block of tool input/output text is large enough to be
+ * collapsed by default. Collapses when it exceeds either the line OR the
+ * character threshold.
+ */
+export function shouldCollapse(str: string): boolean {
+  if (!str) return false
+  return (
+    countLines(str) > COLLAPSE_LINE_THRESHOLD ||
+    str.length > COLLAPSE_CHAR_THRESHOLD
+  )
+}
+
+/**
  * Truncate a string to a max length, adding an ellipsis when truncated.
  */
 export function truncate(str: string, maxLen: number): string {

--- a/src/components/playback/toolCallHelpers.ts
+++ b/src/components/playback/toolCallHelpers.ts
@@ -5,6 +5,8 @@
  * without a DOM/JSX runtime.
  */
 
+import type { ConversationTurn } from '../../types'
+
 export type ToolCategory =
   | 'shell'
   | 'edit'
@@ -212,4 +214,89 @@ export function pickKeyInputArgs(
   }
 
   return result
+}
+
+/**
+ * Kind of a semantic "key moment" in a session, used to label jump links.
+ */
+export type KeyMomentKind = 'plan' | 'agent' | 'prompt' | 'final'
+
+export interface KeyMoment {
+  /** Index into the turns array (matches ConversationTurn position). */
+  index: number
+  kind: KeyMomentKind
+  /** Short Japanese label for the jump link. */
+  label: string
+}
+
+/** A user prompt this long (chars) counts as substantive. */
+export const KEY_MOMENT_PROMPT_MIN_CHARS = 80
+
+const PLAN_TASK_TOOLS = new Set([
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'TaskCreate',
+  'TaskUpdate',
+])
+
+const KEY_MOMENT_LABELS: Record<KeyMomentKind, string> = {
+  plan: '計画',
+  agent: 'エージェント',
+  prompt: 'プロンプト',
+  final: '最終',
+}
+
+/**
+ * Select the semantic "key moments" of a session for the jump-link rail.
+ *
+ * Key moments are:
+ *  - plan/task turns (Enter/ExitPlanMode, TaskCreate/Update)
+ *  - agent turns (spawning subagents)
+ *  - the final turn
+ *  - user prompts only when long/substantive (>= KEY_MOMENT_PROMPT_MIN_CHARS)
+ *
+ * Each turn yields at most one moment; when several signals apply, the
+ * highest-priority kind wins (agent > plan > prompt > final). The result is
+ * sorted ascending by index with no duplicate indices.
+ */
+export function selectKeyMoments(turns: ConversationTurn[]): KeyMoment[] {
+  if (turns.length === 0) return []
+  const lastIndex = turns.length - 1
+  const byIndex = new Map<number, KeyMomentKind>()
+
+  const setKind = (index: number, kind: KeyMomentKind, priority: number) => {
+    const existing = byIndex.get(index)
+    if (existing == null || priority > KIND_PRIORITY[existing]) {
+      byIndex.set(index, kind)
+    }
+  }
+
+  turns.forEach((turn, index) => {
+    const toolCalls = turn.toolCalls ?? []
+    const hasAgent = toolCalls.some(
+      tc => tc.toolName === 'Agent' || tc.toolName === 'Task',
+    )
+    const hasPlan = toolCalls.some(tc => PLAN_TASK_TOOLS.has(tc.toolName ?? ''))
+    const promptLen = (turn.userPrompt ?? '').trim().length
+
+    if (hasAgent) setKind(index, 'agent', KIND_PRIORITY.agent)
+    if (hasPlan) setKind(index, 'plan', KIND_PRIORITY.plan)
+    if (promptLen >= KEY_MOMENT_PROMPT_MIN_CHARS) {
+      setKind(index, 'prompt', KIND_PRIORITY.prompt)
+    }
+  })
+
+  // Final turn is always a key moment (lowest priority, won't override others).
+  setKind(lastIndex, 'final', KIND_PRIORITY.final)
+
+  return [...byIndex.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([index, kind]) => ({ index, kind, label: KEY_MOMENT_LABELS[kind] }))
+}
+
+const KIND_PRIORITY: Record<KeyMomentKind, number> = {
+  agent: 3,
+  plan: 2,
+  prompt: 1,
+  final: 0,
 }

--- a/src/components/playback/toolCallHelpers.ts
+++ b/src/components/playback/toolCallHelpers.ts
@@ -300,3 +300,50 @@ const KIND_PRIORITY: Record<KeyMomentKind, number> = {
   prompt: 1,
   final: 0,
 }
+
+/**
+ * Active filter state for the playback search/filter bar.
+ */
+export interface PlaybackFilter {
+  /** Free-text query (matched against prompt, assistant texts, tool names). */
+  text: string
+  /** Exact tool-name filter ('' = any). */
+  toolName: string
+  /** When true, only key-moment turns match. */
+  keyTurnsOnly: boolean
+}
+
+/**
+ * Pure predicate: does a turn satisfy the active filter?
+ *
+ * AND semantics across the active conditions. Free-text matches the user
+ * prompt, assistant texts, and tool names (case-insensitive). The tool-name
+ * filter requires an exact tool match. `keyTurnsOnly` restricts to indices in
+ * `keyIndices`. An empty/whitespace-only condition is treated as inactive.
+ */
+export function turnMatchesFilter(
+  turn: ConversationTurn,
+  index: number,
+  filter: PlaybackFilter,
+  keyIndices: Set<number>,
+): boolean {
+  if (filter.keyTurnsOnly && !keyIndices.has(index)) return false
+
+  const toolNames = (turn.toolCalls ?? []).map(tc => tc.toolName ?? '')
+
+  if (filter.toolName && !toolNames.includes(filter.toolName)) return false
+
+  const query = filter.text.trim().toLowerCase()
+  if (query) {
+    const haystack = [
+      turn.userPrompt ?? '',
+      ...(turn.assistantTexts ?? []),
+      ...toolNames,
+    ]
+      .join('\n')
+      .toLowerCase()
+    if (!haystack.includes(query)) return false
+  }
+
+  return true
+}

--- a/src/components/playback/toolCallHelpers.ts
+++ b/src/components/playback/toolCallHelpers.ts
@@ -246,6 +246,14 @@ const KEY_MOMENT_LABELS: Record<KeyMomentKind, string> = {
   final: '最終',
 }
 
+/** Resolution order when several key-moment kinds apply to the same turn. */
+const KIND_PRIORITY: Record<KeyMomentKind, number> = {
+  agent: 3,
+  plan: 2,
+  prompt: 1,
+  final: 0,
+}
+
 /**
  * Select the semantic "key moments" of a session for the jump-link rail.
  *
@@ -264,9 +272,9 @@ export function selectKeyMoments(turns: ConversationTurn[]): KeyMoment[] {
   const lastIndex = turns.length - 1
   const byIndex = new Map<number, KeyMomentKind>()
 
-  const setKind = (index: number, kind: KeyMomentKind, priority: number) => {
+  const setKind = (index: number, kind: KeyMomentKind) => {
     const existing = byIndex.get(index)
-    if (existing == null || priority > KIND_PRIORITY[existing]) {
+    if (existing == null || KIND_PRIORITY[kind] > KIND_PRIORITY[existing]) {
       byIndex.set(index, kind)
     }
   }
@@ -279,26 +287,19 @@ export function selectKeyMoments(turns: ConversationTurn[]): KeyMoment[] {
     const hasPlan = toolCalls.some(tc => PLAN_TASK_TOOLS.has(tc.toolName ?? ''))
     const promptLen = (turn.userPrompt ?? '').trim().length
 
-    if (hasAgent) setKind(index, 'agent', KIND_PRIORITY.agent)
-    if (hasPlan) setKind(index, 'plan', KIND_PRIORITY.plan)
+    if (hasAgent) setKind(index, 'agent')
+    if (hasPlan) setKind(index, 'plan')
     if (promptLen >= KEY_MOMENT_PROMPT_MIN_CHARS) {
-      setKind(index, 'prompt', KIND_PRIORITY.prompt)
+      setKind(index, 'prompt')
     }
   })
 
   // Final turn is always a key moment (lowest priority, won't override others).
-  setKind(lastIndex, 'final', KIND_PRIORITY.final)
+  setKind(lastIndex, 'final')
 
   return [...byIndex.entries()]
     .sort((a, b) => a[0] - b[0])
     .map(([index, kind]) => ({ index, kind, label: KEY_MOMENT_LABELS[kind] }))
-}
-
-const KIND_PRIORITY: Record<KeyMomentKind, number> = {
-  agent: 3,
-  plan: 2,
-  prompt: 1,
-  final: 0,
 }
 
 /**

--- a/src/hooks/useSessionFeedback.ts
+++ b/src/hooks/useSessionFeedback.ts
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useState } from 'react'
 import type { FeedbackContextValue } from '../components/playback/feedback/FeedbackContext'
+import type { FeedbackEntry } from '../types'
 import {
   addTag as storeAddTag,
   collectAllTags,
-  getEntry as storeGetEntry,
+  entryKey,
+  loadSessionFeedback,
   removeTag as storeRemoveTag,
   setNote as storeSetNote,
   toggleBookmark as storeToggleBookmark,
@@ -20,13 +22,23 @@ export function useSessionFeedback(sessionId: string | null): FeedbackContextVal
   const [version, setVersion] = useState(0)
   const bump = useCallback(() => setVersion(v => v + 1), [])
 
+  // Parse the current session's feedback blob exactly once per mutation and
+  // index it by entryKey, so per-block/per-turn lookups during a render are
+  // O(1) instead of a full getItem + JSON.parse of the whole blob each call.
+  const entryMap = useMemo(() => {
+    const map = new Map<string, FeedbackEntry>()
+    if (!sessionId) return map
+    for (const entry of loadSessionFeedback(sessionId)) {
+      map.set(entryKey(entry.turnId, entry.blockId), entry)
+    }
+    return map
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reload after every mutation
+  }, [sessionId, version])
+
   const getEntry = useCallback(
     (turnId: number, blockId?: string) =>
-      sessionId ? storeGetEntry(sessionId, turnId, blockId) : null,
-    // `version` is intentionally a dependency so this fn's identity changes
-    // after every mutation, forcing consumers to re-read the latest entry.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sessionId, version],
+      entryMap.get(entryKey(turnId, blockId)) ?? null,
+    [entryMap],
   )
 
   const toggleBookmark = useCallback(

--- a/src/hooks/useSessionFeedback.ts
+++ b/src/hooks/useSessionFeedback.ts
@@ -1,0 +1,75 @@
+import { useCallback, useMemo, useState } from 'react'
+import type { FeedbackContextValue } from '../components/playback/feedback/FeedbackContext'
+import {
+  addTag as storeAddTag,
+  collectAllTags,
+  getEntry as storeGetEntry,
+  removeTag as storeRemoveTag,
+  setNote as storeSetNote,
+  toggleBookmark as storeToggleBookmark,
+} from '../components/playback/feedback/feedbackStore'
+
+/**
+ * React binding over the pure feedbackStore, scoped to one session.
+ *
+ * The store itself is the source of truth (localStorage); this hook keeps a
+ * `version` counter that is bumped after every mutation so consuming
+ * components re-render. Returns a value shaped for FeedbackContext.
+ */
+export function useSessionFeedback(sessionId: string | null): FeedbackContextValue {
+  const [version, setVersion] = useState(0)
+  const bump = useCallback(() => setVersion(v => v + 1), [])
+
+  const getEntry = useCallback(
+    (turnId: number, blockId?: string) =>
+      sessionId ? storeGetEntry(sessionId, turnId, blockId) : null,
+    // `version` is intentionally a dependency so this fn's identity changes
+    // after every mutation, forcing consumers to re-read the latest entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sessionId, version],
+  )
+
+  const toggleBookmark = useCallback(
+    (turnId: number, blockId?: string) => {
+      if (!sessionId) return
+      storeToggleBookmark(sessionId, turnId, blockId)
+      bump()
+    },
+    [sessionId, bump],
+  )
+
+  const addTag = useCallback(
+    (turnId: number, blockId: string | undefined, tag: string) => {
+      if (!sessionId) return
+      storeAddTag(sessionId, turnId, blockId, tag)
+      bump()
+    },
+    [sessionId, bump],
+  )
+
+  const removeTag = useCallback(
+    (turnId: number, blockId: string | undefined, tag: string) => {
+      if (!sessionId) return
+      storeRemoveTag(sessionId, turnId, blockId, tag)
+      bump()
+    },
+    [sessionId, bump],
+  )
+
+  const setNote = useCallback(
+    (turnId: number, blockId: string | undefined, note: string) => {
+      if (!sessionId) return
+      storeSetNote(sessionId, turnId, blockId, note)
+      bump()
+    },
+    [sessionId, bump],
+  )
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- recompute when feedback changes
+  const allTags = useMemo(() => collectAllTags(), [version, sessionId])
+
+  return useMemo(
+    () => ({ getEntry, toggleBookmark, addTag, removeTag, setNote, allTags }),
+    [getEntry, toggleBookmark, addTag, removeTag, setNote, allTags],
+  )
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -303,6 +303,18 @@ export interface HotFile {
   sessionId: string
 }
 
+// === Playback Feedback (Bookmark / Tag / Annotate, issue #23) ===
+export interface FeedbackEntry {
+  sessionId: string
+  /** Numeric ConversationTurn.turnIndex (there is no string turn id). */
+  turnId: number
+  /** Tool-call block id (toolUseId) for block-level feedback; absent = turn-level. */
+  blockId?: string
+  bookmarked: boolean
+  tags: string[]
+  note: string
+}
+
 // === Graph Context for Skill Synthesis ===
 export interface ConnectedTopicInfo {
   id: string


### PR DESCRIPTION
Closes #22
Closes #23

両issueが同じplaybackコンポーネント群を触るため1ブランチに**8コミット**（#22→#23）でまとめています。

## #22 可読性（4コミット）
1. 長いtool出力**＋入力**を行数表示付きで折り畳み（`countLines`/`shouldCollapse`、>15行 OR >500字）
2. SubagentBranch を**再帰化**（実 subagents マップを配線、深さインデント/枠色、MAX_DEPTH=6）
3. 意味的**key-momentsジャンプレール**（plan/agent/final/長いprompt≥80字、`selectKeyMoments`）
4. 検索/フィルタバー（free-text・tool名・key-turnsのみ、AND）。非マッチturnはDOM保持のまま淡色＋折り畳み（minimap/キーボードnavのindex不変）、`matches: N`表示

## #23 フィードバック（4コミット）
5. `FeedbackEntry` 型＋framework非依存 `feedbackStore`（localStorage単一blob `crune.feedback.v1`、`Record<sessionId, FeedbackEntry[]>`、injectable Storage、壊れJSON復旧）
6. `useSessionFeedback` hook ＋ `FeedbackContext`（PlanModeContext踏襲）
7. `FeedbackCluster`（⭐bookmark/🏷tag/📝note）＋ `<datalist>` autocomplete、turn単位
8. block単位（ToolCallBlockのtoolUseIdキー、tool callのみ）

## Tests (TDD)
純粋ロジックのみテスト（countLines/shouldCollapse/selectKeyMoments/turnMatchesFilter＋feedbackStore）。UI配線は当repo慣習でテストなし。全307 green、`npm run build` 成功。

## 既知の軽微事項（UI・機能影響なし）
block単位popoverが短いtool blockで `.tool-call-block` の overflow:hidden に視覚的にクリップされ得る。`src/types/session.ts` を cli PR(#59相当ではなく#62側)と別interfaceで共有編集。

🤖 Generated with [Claude Code](https://claude.com/claude-code)