### PR TITLE
Fix skill evaluation scoring every skill 0 (folded scalars + missing closing fence) (#64)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.7",
         "react-force-graph-2d": "^1.29.1",
+        "yaml": "^2.9.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -4035,6 +4036,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.7",
     "react-force-graph-2d": "^1.29.1",
+    "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/scripts/__tests__/skill-evaluator.test.ts
+++ b/scripts/__tests__/skill-evaluator.test.ts
@@ -191,6 +191,41 @@ deploy steps
     expect(result.parsed?.requires).toEqual(["setup-env"]);
     expect(result.parsed?.next).toEqual(["smoke-test"]);
   });
+
+  // Regression for #64: the synthesizer emits long descriptions as YAML folded
+  // block scalars (`>-`); the old hand-rolled parser rejected them and forced
+  // every skill's overallScore to 0.
+  it("accepts a folded (>-) multi-line description", () => {
+    const md = `---
+name: worktree-parallel-pr-workflow
+description: >-
+  Use when the user asks to break work into independent PRs, fan out
+  worktrees, and synthesize the results. Triggers on "split into PRs".
+---
+
+body content
+`;
+    const result = validateStructure(md);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.parsed?.description).toContain("independent PRs");
+    // Folded scalars join wrapped lines with spaces (no embedded newlines).
+    expect(result.parsed?.description).not.toContain("\n");
+  });
+
+  it("accepts a literal (|) multi-line description", () => {
+    const md = `---
+name: my-skill
+description: |
+  Line one of the description, long enough to pass the minimum length check.
+  Line two continues on a new line.
+---
+
+body content
+`;
+    const result = validateStructure(md);
+    expect(result.valid).toBe(true);
+  });
 });
 
 describe("extractFrontmatter", () => {
@@ -211,6 +246,19 @@ body
     const { data } = extractFrontmatter(md);
     expect(data.name).toBe("quoted-name");
     expect(data.description).toBe("single quoted long enough description for the validator");
+  });
+
+  it("parses folded block scalars (>-) into a single-line string", () => {
+    const md = `---
+name: x
+description: >-
+  folded line one
+  folded line two
+---
+body
+`;
+    const { data } = extractFrontmatter(md);
+    expect(data.description).toBe("folded line one folded line two");
   });
 });
 

--- a/scripts/__tests__/skill-synthesizer.test.ts
+++ b/scripts/__tests__/skill-synthesizer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripSynthesisPreamble,
+  ensureClosingFence,
+} from "../skill-synthesizer.js";
+import { validateStructure } from "../skill-evaluator.js";
+
+describe("stripSynthesisPreamble", () => {
+  it("returns markdown starting at the opening fence when there is no preamble", () => {
+    const md = "---\nname: x\ndescription: a long enough description here.\n---\n\n# Body\ntext\n";
+    expect(stripSynthesisPreamble(md)).toBe(md);
+  });
+
+  it("strips a leading model preamble before the frontmatter", () => {
+    const raw =
+      "Now I have a thorough understanding.\n\n---\nname: x\ndescription: a long enough description here.\n---\n\n# Body\ntext\n";
+    expect(stripSynthesisPreamble(raw)).toBe(
+      "---\nname: x\ndescription: a long enough description here.\n---\n\n# Body\ntext\n"
+    );
+  });
+});
+
+describe("ensureClosingFence", () => {
+  it("inserts a missing closing fence before the body heading", () => {
+    // Regression for #64: the synthesizer emitted the opening fence + a folded
+    // description but no closing fence, flowing straight into the body.
+    const broken =
+      "---\nname: worktree-parallel-pr-workflow\ndescription: >-\n  Use when the user asks to break work into independent PRs and fan out worktrees.\n\n# Worktree並行PR開発\n\n## Overview\nbody\n";
+    const fixed = ensureClosingFence(broken);
+    expect(fixed).toContain("\n---\n\n# Worktree並行PR開発");
+    // The repaired document now validates structurally.
+    const result = validateStructure(fixed);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.parsed?.name).toBe("worktree-parallel-pr-workflow");
+    expect(result.parsed?.description).toContain("independent PRs");
+  });
+
+  it("leaves a document that already has a closing fence unchanged", () => {
+    const ok =
+      "---\nname: x\ndescription: a long enough description here for the validator.\n---\n\n# Body\ntext\n";
+    expect(ensureClosingFence(ok)).toBe(ok);
+  });
+
+  it("leaves text without an opening fence unchanged", () => {
+    const noFm = "# Just a heading\n\nbody\n";
+    expect(ensureClosingFence(noFm)).toBe(noFm);
+  });
+
+  it("is a no-op when the body heading cannot be located", () => {
+    const weird = "---\nname: x\ndescription: y\nstill frontmatter-ish\n";
+    expect(ensureClosingFence(weird)).toBe(weird);
+  });
+});

--- a/scripts/skill-evaluator.ts
+++ b/scripts/skill-evaluator.ts
@@ -10,6 +10,7 @@
  * to a follow-up issue. Callers may still write the file when scores are low.
  */
 import { spawn } from "node:child_process";
+import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import type { SkillEvaluation } from "../src/types/session.js";
 
@@ -68,16 +69,11 @@ export interface EvaluatorOptions {
 // ---------- Frontmatter parsing ----------
 
 /**
- * Minimal YAML frontmatter parser tailored to SKILL.md (no full YAML lib needed).
- * Supports:
- *   - simple `key: value` scalars
- *   - inline arrays `key: [a, b, c]`
- *   - indented list items under a key:
- *       key:
- *         - a
- *         - b
- *   - quoted strings (single or double)
- * Throws on malformed structure.
+ * Extract and parse the YAML frontmatter block from SKILL.md. The block is
+ * delimited by a leading `---` and a closing `---`; the body after it is
+ * ignored here. The frontmatter is parsed with a real YAML parser so block /
+ * folded scalars (`>-`, `>`, `|`, `|-`) and flow collections are handled
+ * correctly. Throws when the fences are missing or the YAML is invalid.
  */
 export function extractFrontmatter(markdown: string): {
   raw: string;
@@ -100,69 +96,24 @@ export function extractFrontmatter(markdown: string): {
   }
   const raw = after.slice(0, closeIdx);
 
-  const data: Record<string, unknown> = {};
-  const lines = raw.split("\n");
-  let currentListKey: string | null = null;
-  let listAccumulator: string[] = [];
-
-  const flushList = () => {
-    if (currentListKey !== null) {
-      data[currentListKey] = listAccumulator;
-      currentListKey = null;
-      listAccumulator = [];
-    }
-  };
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line.trim() === "") continue;
-
-    // Indented list item under previous key.
-    if (currentListKey !== null && /^\s+-\s+/.test(line)) {
-      const value = line.replace(/^\s+-\s+/, "").trim();
-      listAccumulator.push(unquote(value));
-      continue;
-    }
-
-    // New key — flush any pending list.
-    flushList();
-
-    const m = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/);
-    if (!m) {
-      throw new Error(`malformed frontmatter line: ${JSON.stringify(line)}`);
-    }
-    const [, key, rawValue] = m;
-    const value = rawValue.trim();
-
-    if (value === "") {
-      // Possibly a list opener.
-      currentListKey = key;
-      listAccumulator = [];
-      continue;
-    }
-
-    if (value.startsWith("[") && value.endsWith("]")) {
-      const inner = value.slice(1, -1).trim();
-      data[key] = inner === ""
-        ? []
-        : inner.split(",").map((s) => unquote(s.trim()));
-      continue;
-    }
-
-    data[key] = unquote(value);
+  // Parse the frontmatter block with a real YAML parser so block/folded
+  // scalars (`>-`, `>`, `|`, `|-`) and flow collections are handled correctly.
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (e) {
+    throw new Error(`malformed frontmatter: invalid YAML (${(e as Error).message})`, { cause: e });
   }
-  flushList();
 
-  return { raw, data };
-}
-
-function unquote(s: string): string {
-  if (s.length >= 2) {
-    if ((s.startsWith("\"") && s.endsWith("\"")) || (s.startsWith("'") && s.endsWith("'"))) {
-      return s.slice(1, -1);
-    }
+  // An empty frontmatter block is a valid (empty) mapping.
+  if (parsed === null || parsed === undefined) {
+    return { raw, data: {} };
   }
-  return s;
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("malformed frontmatter: expected a mapping of keys");
+  }
+
+  return { raw, data: parsed as Record<string, unknown> };
 }
 
 // ---------- Structural schema ----------

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -266,10 +266,43 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
  */
 export function stripSynthesisPreamble(raw: string): string {
   const trimmed = raw.trimStart();
-  if (trimmed.startsWith("---")) return trimmed;
-  const idx = trimmed.indexOf("\n---");
-  if (idx !== -1) return trimmed.slice(idx + 1);
-  return trimmed;
+  let fromFrontmatter: string;
+  if (trimmed.startsWith("---")) {
+    fromFrontmatter = trimmed;
+  } else {
+    const idx = trimmed.indexOf("\n---");
+    fromFrontmatter = idx !== -1 ? trimmed.slice(idx + 1) : trimmed;
+  }
+  return ensureClosingFence(fromFrontmatter);
+}
+
+/**
+ * The synthesizer sometimes emits the opening `---` frontmatter fence but omits
+ * the closing one, flowing straight into the markdown body. That yields an
+ * invalid SKILL.md — unusable once installed, and rejected by structural
+ * validation (every such skill then scores 0). When an opening fence is present
+ * without a matching closing fence, insert one just before the body (the first
+ * markdown heading).
+ */
+export function ensureClosingFence(md: string): string {
+  if (!md.startsWith("---")) return md;
+  const afterOpen = md.indexOf("\n");
+  if (afterOpen === -1) return md;
+  const body = md.slice(afterOpen + 1);
+  // A closing fence already exists — nothing to do.
+  if (/^---\s*$/m.test(body)) return md;
+
+  const lines = body.split("\n");
+  // The markdown body begins at the first top-level heading.
+  const headingIdx = lines.findIndex((l) => /^#{1,6}\s/.test(l));
+  if (headingIdx === -1) return md; // can't locate the body; leave as-is
+
+  // Frontmatter = lines before the heading, minus trailing blank lines.
+  let fmEnd = headingIdx;
+  while (fmEnd > 0 && lines[fmEnd - 1].trim() === "") fmEnd--;
+  const frontmatter = lines.slice(0, fmEnd);
+  const rest = lines.slice(headingIdx);
+  return ["---", ...frontmatter, "---", "", ...rest].join("\n");
 }
 
 // ---------- Distill with Claude CLI ----------


### PR DESCRIPTION
Closes #64

A full regeneration scored **every** synthesized skill `0` and triggered the bounded re-synthesis retry for all of them. Investigation found **two** distinct root causes (both make a well-formed-ish skill fail structural validation):

### 1. Parser rejected YAML folded scalars
`extractFrontmatter` was a hand-rolled line parser that only understood `key: value` and `- list`. The synthesizer emits long descriptions as folded block scalars:

```yaml
description: >-
  Use when the user asks to ...
```

The indented continuation threw `malformed frontmatter line`. **Fix:** parse the frontmatter with the `yaml` library (handles `>-`/`>`/`|`/`|-` and flow collections). Added `yaml` as a dependency.

### 2. Synthesizer omitted the closing `---` fence
4 of 5 synthesized skills had the opening fence + folded description but **no closing `---`**, flowing straight into the body — an invalid SKILL.md (unusable when installed, rejected by validation). **Fix:** `stripSynthesisPreamble` now repairs output via `ensureClosingFence`, inserting a closing fence before the first body heading when one is missing.

### Result (verified against the 5 real synthesized skills in `overview.json`)
- Before: 5/5 score 0 (bogus parser failure).
- After: **3/5 validate**; the other 2 now fail for a *genuine, actionable* reason — `description must be at most 500 characters` (the LLM wrote an over-long description). That is correct evaluator behavior, and it drives a meaningful re-synthesis instead of a guaranteed-0 reroll.

### Tests
- `skill-evaluator.test.ts`: folded (`>-`) and literal (`|`) descriptions; existing malformed/missing-fence cases still pass.
- New `skill-synthesizer.test.ts`: `stripSynthesisPreamble` + `ensureClosingFence` (insert-when-missing, no-op when present/no-opening-fence/no-heading).
- Full suite green; tsc/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)