### PR TITLE
fix(types): add evaluation field to pipeline SkillCandidate

### DIFF
--- a/scripts/knowledge-graph/types.ts
+++ b/scripts/knowledge-graph/types.ts
@@ -2,6 +2,8 @@
  * Type definitions for semantic knowledge graph construction.
  */
 
+import type { SkillEvaluation } from "../../src/types/session.js";
+
 // ─── Input types (subset of analyze-sessions.ts types) ──────────────────────
 
 export interface SessionInput {
@@ -148,6 +150,7 @@ export interface SkillCandidate {
   skillMarkdown: string;
   synthesizedMarkdown?: string;
   hookJson?: string;
+  evaluation?: SkillEvaluation;
 }
 
 // ─── Knowledge graph options ─────────────────────────────────────────────────


### PR DESCRIPTION
## Why
`npm run build:cli` (`tsc -p tsconfig.cli.json`) failed on `main` with 2 errors:

```
scripts/analyze-sessions.ts(618,22): error TS2339: Property 'evaluation' does not exist on type 'SkillCandidate'.
scripts/analyze-sessions.ts(624,22): error TS2339: Property 'evaluation' does not exist on type 'SkillCandidate'.
```

`analyze-sessions.ts` assigns `candidate.evaluation` (issue #20), but the pipeline-side `SkillCandidate` in `scripts/knowledge-graph/types.ts` was missing the `evaluation?: SkillEvaluation` field that already exists on its `src/types/session.ts` twin.

## What
- Import `SkillEvaluation` and add `evaluation?: SkillEvaluation` to the pipeline `SkillCandidate`.

Pre-existing bug, surfaced while implementing Wave 4/5. Unblocks `build:cli` for the follow-up RAG PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)