### PR TITLE
feat(#24): feed bookmark/tag/note feedback into Skill synthesis as a human signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ dist-ssr
 
 # Session data
 public/data/sessions/
+# Human playback feedback synced from the browser (issue #24)
+public/data/feedback.json
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,19 @@ All domain types are in `src/types/session.ts`. Key types:
 Pipeline-internal types in `scripts/knowledge-graph/types.ts`:
 - `FacetsData` --- parsed `/insights` facets data per session
 - `FacetsInsightsSummary` --- aggregated facets for a topic (goals, categories, success rate, frictions)
+
+## Human Feedback (issue #24)
+
+Playback feedback (bookmark / tag / note, issue #23) is fed into skill synthesis as a human signal.
+
+**Persistence bridge**: localStorage (`crune.feedback.v1`) stays the offline source of truth. The UI best-effort POSTs each session's entries to the skill-server (`POST /api/feedback`, fire-and-forget via `src/components/playback/feedback/feedbackSync.ts`), which merges them into `public/data/feedback.json` (`GET /api/feedback` reads it back). The offline pipeline reads that file via `scripts/feedback-reader.ts`.
+
+**Meaningful tags** (free-text otherwise; constants in `src/components/playback/feedback/tagSemantics.ts` and mirrored in `scripts/feedback-reader.ts`):
+- `reusable` --- this turn is VALUABLE evidence to replicate in a skill.
+- `anti-pattern` --- this turn is a counter-example; skills should avoid it.
+
+Both are surfaced first in the `TagInput` datalist.
+
+**Synthesis** (gated behind `--use-human-feedback`, default OFF for A/B): `buildSynthesisPrompt` adds a "Human-Flagged Moments" section listing bookmarked turns, `reusable` turns marked as evidence to replicate, and `anti-pattern` turns marked as counter-examples to avoid. `--feedback-file <path>` overrides the default `public/data/feedback.json`.
+
+**Reusability score**: an optional `humanSignal` term (`ReusabilityScore.humanSignal`, weight 0.10) boosts clusters with bookmarks/`reusable` tags and dampens for `anti-pattern`, folded in alongside `successRate`/`helpfulness`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ Flags:
 - `--skip-synthesize` --- Skip LLM synthesis for faster builds
 - `--facets-dir <path>` --- Custom facets directory (default: `~/.claude/usage-data/facets`)
 - `--skip-facets` --- Skip `/insights` refresh and facets integration
+- `--use-human-feedback` --- Fold playback feedback (issue #24) into synthesis + reusability scoring (default OFF for A/B)
+- `--feedback-file <path>` --- Custom feedback file (default `public/data/feedback.json`)
 
 Pre-synthesized results are stored in `overview.json` as `synthesizedMarkdown` on each `SkillCandidate` and displayed immediately in the Knowledge Graph UI. Synthesis output is post-processed by `stripSynthesisPreamble()` to remove any LLM preamble before the YAML frontmatter.
 

--- a/scripts/__tests__/feedback-reader.test.ts
+++ b/scripts/__tests__/feedback-reader.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeFeedbackBlob,
+  mergeFeedbackBlob,
+  selectFlaggedTurns,
+  renderTurnSnippet,
+  computeSessionFeedbackCounts,
+  REUSABLE_TAG,
+  ANTI_PATTERN_TAG,
+  type FeedbackEntry,
+} from "../feedback-reader.js";
+import type { SessionInput } from "../knowledge-graph/types.js";
+
+function entry(partial: Partial<FeedbackEntry>): FeedbackEntry {
+  return {
+    sessionId: "s1",
+    turnId: 0,
+    bookmarked: false,
+    tags: [],
+    note: "",
+    ...partial,
+  };
+}
+
+describe("normalizeFeedbackBlob", () => {
+  it("returns {} for non-object input", () => {
+    expect(normalizeFeedbackBlob(null)).toEqual({});
+    expect(normalizeFeedbackBlob([])).toEqual({});
+    expect(normalizeFeedbackBlob("nope")).toEqual({});
+  });
+
+  it("drops empty entries and empty session buckets", () => {
+    const blob = normalizeFeedbackBlob({
+      s1: [entry({ turnId: 1, bookmarked: true }), entry({ turnId: 2 })],
+      s2: [entry({ turnId: 0 })],
+    });
+    expect(blob.s1).toHaveLength(1);
+    expect(blob.s1[0].turnId).toBe(1);
+    expect(blob.s2).toBeUndefined();
+  });
+
+  it("coerces malformed entries (missing tags/note) and skips invalid shapes", () => {
+    const blob = normalizeFeedbackBlob({
+      s1: [
+        { sessionId: "s1", turnId: 3, bookmarked: true },
+        { sessionId: "s1" }, // missing turnId — dropped
+        { turnId: 5 }, // missing sessionId — dropped
+      ],
+    });
+    expect(blob.s1).toHaveLength(1);
+    expect(blob.s1[0]).toMatchObject({ turnId: 3, tags: [], note: "" });
+  });
+});
+
+describe("mergeFeedbackBlob", () => {
+  it("adds a session's entries without touching others", () => {
+    const current = { s1: [entry({ turnId: 0, bookmarked: true })] };
+    const next = mergeFeedbackBlob(current, "s2", [entry({ sessionId: "s2", turnId: 1, note: "x" })]);
+    expect(next.s1).toHaveLength(1);
+    expect(next.s2).toHaveLength(1);
+    // input is not mutated
+    expect(current).not.toHaveProperty("s2");
+  });
+
+  it("clears a bucket when posted entries are all empty", () => {
+    const current = { s1: [entry({ turnId: 0, bookmarked: true })] };
+    const next = mergeFeedbackBlob(current, "s1", [entry({ turnId: 0 })]);
+    expect(next.s1).toBeUndefined();
+  });
+
+  it("forces the sessionId onto merged entries", () => {
+    const next = mergeFeedbackBlob({}, "s9", [entry({ sessionId: "wrong", turnId: 2, bookmarked: true })]);
+    expect(next.s9[0].sessionId).toBe("s9");
+  });
+});
+
+describe("selectFlaggedTurns", () => {
+  const feedback = new Map<string, FeedbackEntry[]>([
+    [
+      "s1",
+      [
+        entry({ turnId: 0, bookmarked: true }),
+        entry({ turnId: 1, tags: [REUSABLE_TAG] }),
+        entry({ turnId: 2, tags: [ANTI_PATTERN_TAG] }),
+        entry({ turnId: 3, note: "just a note" }), // not flagged
+      ],
+    ],
+    ["s2", [entry({ sessionId: "s2", turnId: 0, bookmarked: true })]],
+  ]);
+
+  it("selects bookmarked or meaningfully-tagged turns only, for the given sessions", () => {
+    const flagged = selectFlaggedTurns(feedback, ["s1"]);
+    expect(flagged.map((f) => f.turnId)).toEqual([0, 1, 2]);
+  });
+
+  it("classifies reusable / anti-pattern flags", () => {
+    const flagged = selectFlaggedTurns(feedback, ["s1"]);
+    expect(flagged.find((f) => f.turnId === 1)?.reusable).toBe(true);
+    expect(flagged.find((f) => f.turnId === 2)?.antiPattern).toBe(true);
+    expect(flagged.find((f) => f.turnId === 0)?.reusable).toBe(false);
+  });
+
+  it("is case-insensitive for tag matching", () => {
+    const fb = new Map([["s1", [entry({ turnId: 0, tags: ["Reusable"] })]]]);
+    expect(selectFlaggedTurns(fb, ["s1"])[0].reusable).toBe(true);
+  });
+
+  it("ignores sessions not present in the feedback map", () => {
+    expect(selectFlaggedTurns(feedback, ["unknown"])).toEqual([]);
+  });
+});
+
+describe("renderTurnSnippet", () => {
+  const sessions = new Map<string, SessionInput>([
+    [
+      "s1",
+      {
+        sessionId: "s1",
+        projectDisplayName: "p",
+        turns: [
+          { userPrompt: "  fix the   bug  ", assistantTexts: ["I will fix it.", "second"], toolCalls: [] },
+          { userPrompt: "", assistantTexts: [], toolCalls: [] },
+        ],
+        subagents: {},
+        meta: {
+          sessionId: "s1",
+          createdAt: "",
+          lastActiveAt: "",
+          durationMinutes: 0,
+          filesEdited: [],
+          gitBranch: "",
+          toolBreakdown: {},
+          subagentCount: 0,
+        },
+      },
+    ],
+  ]);
+
+  it("renders userPrompt + first assistantText, whitespace-collapsed", () => {
+    expect(renderTurnSnippet(sessions, "s1", 0)).toBe("User: fix the bug / Claude: I will fix it.");
+  });
+
+  it("truncates long text to maxLen with an ellipsis", () => {
+    const snippet = renderTurnSnippet(sessions, "s1", 0, 10);
+    expect(snippet).not.toBeNull();
+    // "User: " + 9 chars + "…"
+    expect(snippet).toContain("…");
+  });
+
+  it("returns null for an all-empty turn", () => {
+    expect(renderTurnSnippet(sessions, "s1", 1)).toBeNull();
+  });
+
+  it("returns null for unknown session/turn", () => {
+    expect(renderTurnSnippet(sessions, "s1", 99)).toBeNull();
+    expect(renderTurnSnippet(sessions, "ghost", 0)).toBeNull();
+  });
+});
+
+describe("computeSessionFeedbackCounts", () => {
+  it("aggregates bookmark / reusable / anti-pattern counts per session", () => {
+    const feedback = new Map<string, FeedbackEntry[]>([
+      [
+        "s1",
+        [
+          entry({ turnId: 0, bookmarked: true, tags: [REUSABLE_TAG] }),
+          entry({ turnId: 1, tags: [REUSABLE_TAG] }),
+          entry({ turnId: 2, tags: [ANTI_PATTERN_TAG] }),
+        ],
+      ],
+      ["s2", [entry({ sessionId: "s2", turnId: 0, note: "only a note" })]], // no signal
+    ]);
+    const counts = computeSessionFeedbackCounts(feedback);
+    expect(counts.get("s1")).toEqual({ bookmarked: true, reusableCount: 2, antiPatternCount: 1 });
+    expect(counts.has("s2")).toBe(false);
+  });
+});

--- a/scripts/__tests__/human-feedback-synthesis.test.ts
+++ b/scripts/__tests__/human-feedback-synthesis.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSynthesisPrompt,
+  buildHumanFeedbackSection,
+  type SynthesisRequest,
+  type HumanFeedbackSignal,
+} from "../skill-synthesizer.js";
+import { parseArgs } from "../analyze-sessions.js";
+
+function baseRequest(): SynthesisRequest {
+  return {
+    skillCandidate: { topicId: "t1", reusabilityScore: 0.5, skillMarkdown: "# heuristic" },
+    topicNode: {
+      id: "t1",
+      label: "Bugfix",
+      keywords: ["fix", "bug"],
+      dominantRole: "user-driven",
+      projects: ["p"],
+      project: "p",
+      sessionCount: 2,
+      totalDurationMinutes: 30,
+      totalToolCalls: 10,
+      toolSignature: [{ tool: "Edit", weight: 0.5 }],
+      representativePrompts: ["fix the bug"],
+      suggestedPrompt: "fix",
+      reusabilityScore: {
+        overall: 0.5,
+        frequency: 0.5,
+        timeCost: 0.5,
+        crossProjectScore: 0,
+        recency: 0.5,
+      },
+      betweennessCentrality: 0,
+      degreeCentrality: 0,
+    },
+  };
+}
+
+const reusable: HumanFeedbackSignal = {
+  sessionId: "s1",
+  turnId: 1,
+  snippet: "User: write a test first / Claude: ok",
+  note: "great TDD example",
+  reusable: true,
+  antiPattern: false,
+};
+
+const antiPattern: HumanFeedbackSignal = {
+  sessionId: "s1",
+  turnId: 5,
+  snippet: "User: just force push / Claude: done",
+  note: "",
+  reusable: false,
+  antiPattern: true,
+};
+
+const bookmarkOnly: HumanFeedbackSignal = {
+  sessionId: "s2",
+  turnId: 0,
+  snippet: "User: interesting / Claude: yes",
+  note: "",
+  reusable: false,
+  antiPattern: false,
+};
+
+describe("buildHumanFeedbackSection", () => {
+  it("returns empty string when there is no feedback", () => {
+    expect(buildHumanFeedbackSection([])).toBe("");
+  });
+
+  it("marks reusable turns as VALUABLE evidence to replicate", () => {
+    const section = buildHumanFeedbackSection([reusable]);
+    expect(section).toContain("Human-Flagged Moments");
+    expect(section).toContain("Reusable");
+    expect(section).toContain("replicate");
+    expect(section).toContain("write a test first");
+    expect(section).toContain("great TDD example");
+  });
+
+  it("marks anti-pattern turns as a counter-example to avoid", () => {
+    const section = buildHumanFeedbackSection([antiPattern]);
+    expect(section).toContain("Anti-Pattern");
+    expect(section).toMatch(/avoid/i);
+    expect(section).toContain("force push");
+  });
+
+  it("groups bookmark-only turns separately as noteworthy", () => {
+    const section = buildHumanFeedbackSection([bookmarkOnly]);
+    expect(section).toContain("Bookmarked");
+    expect(section).not.toContain("Reusable");
+    expect(section).not.toContain("Anti-Pattern");
+  });
+
+  it("renders a placeholder when the snippet is unavailable", () => {
+    const section = buildHumanFeedbackSection([{ ...reusable, snippet: null }]);
+    expect(section).toContain("(snippet unavailable)");
+  });
+});
+
+describe("buildSynthesisPrompt human feedback gating", () => {
+  it("omits the section entirely when humanFeedback is absent", () => {
+    const prompt = buildSynthesisPrompt(baseRequest());
+    expect(prompt).not.toContain("Human-Flagged Moments");
+  });
+
+  it("omits the section when humanFeedback is an empty array", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), humanFeedback: [] });
+    expect(prompt).not.toContain("Human-Flagged Moments");
+  });
+
+  it("includes the reusable/anti-pattern guidance only when humanFeedback is present", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), humanFeedback: [reusable, antiPattern] });
+    expect(prompt).toContain("Human-Flagged Moments");
+    expect(prompt).toContain("Reusable");
+    expect(prompt).toContain("Anti-Pattern");
+    // A task rule reinforcing the human signal priority is appended.
+    expect(prompt).toMatch(/Prioritize the \*\*Human-Flagged Moments\*\*/);
+  });
+});
+
+describe("parseArgs human feedback flags", () => {
+  it("defaults useHumanFeedback OFF and feedback file to public/data/feedback.json", () => {
+    const args = parseArgs([]);
+    expect(args.useHumanFeedback).toBe(false);
+    expect(args.feedbackFile).toMatch(/public\/data\/feedback\.json$/);
+  });
+
+  it("enables with --use-human-feedback", () => {
+    expect(parseArgs(["--use-human-feedback"]).useHumanFeedback).toBe(true);
+  });
+
+  it("overrides the path with --feedback-file", () => {
+    expect(parseArgs(["--feedback-file", "/tmp/fb.json"]).feedbackFile).toBe("/tmp/fb.json");
+  });
+});

--- a/scripts/__tests__/reusability-human-signal.test.ts
+++ b/scripts/__tests__/reusability-human-signal.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSessionHumanSignal,
+  aggregateHumanSignal,
+  computeReusabilityScores,
+  HUMAN_SIGNAL_WEIGHT,
+} from "../knowledge-graph/reusability.js";
+import type { TopicNode } from "../knowledge-graph/types.js";
+
+describe("computeSessionHumanSignal", () => {
+  it("returns the neutral baseline 0.5 with no feedback", () => {
+    expect(computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 0 })).toBe(0.5);
+  });
+
+  it("a bookmark boosts above the baseline", () => {
+    const signal = computeSessionHumanSignal({ bookmarked: true, reusableCount: 0, antiPatternCount: 0 });
+    expect(signal).toBeGreaterThan(0.5);
+  });
+
+  it("is monotonic non-decreasing in reusableCount", () => {
+    const s0 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 0 });
+    const s1 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 1, antiPatternCount: 0 });
+    const s2 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 2, antiPatternCount: 0 });
+    expect(s1).toBeGreaterThan(s0);
+    expect(s2).toBeGreaterThanOrEqual(s1);
+  });
+
+  it("is monotonic non-increasing in antiPatternCount", () => {
+    const s0 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 0 });
+    const s1 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 1 });
+    const s2 = computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 2 });
+    expect(s1).toBeLessThan(s0);
+    expect(s2).toBeLessThanOrEqual(s1);
+  });
+
+  it("clamps to [0,1]", () => {
+    const hi = computeSessionHumanSignal({ bookmarked: true, reusableCount: 99, antiPatternCount: 0 });
+    const lo = computeSessionHumanSignal({ bookmarked: false, reusableCount: 0, antiPatternCount: 99 });
+    expect(hi).toBeLessThanOrEqual(1);
+    expect(lo).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("aggregateHumanSignal", () => {
+  it("returns 0.5 for an empty topic", () => {
+    expect(aggregateHumanSignal([], new Map())).toBe(0.5);
+  });
+
+  it("averages per-session signals, treating unknown sessions as neutral", () => {
+    const map = new Map([["s1", 1.0]]);
+    // s1 (1.0) + s2 (neutral 0.5) -> 0.75
+    expect(aggregateHumanSignal(["s1", "s2"], map)).toBeCloseTo(0.75, 5);
+  });
+});
+
+function makeTopic(id: string, sessionIds: string[]): TopicNode {
+  return {
+    id,
+    label: id,
+    keywords: [],
+    project: "p",
+    projects: ["p"],
+    sessionIds,
+    sessionCount: sessionIds.length,
+    totalDurationMinutes: 60,
+    totalToolCalls: 10,
+    firstSeen: "2026-01-01T00:00:00.000Z",
+    lastSeen: "2026-01-01T00:00:00.000Z",
+    betweennessCentrality: 0,
+    degreeCentrality: 0,
+    communityId: 0,
+    representativePrompts: [],
+    suggestedPrompt: "",
+    toolSignature: [],
+    dominantRole: "user-driven",
+    reusabilityScore: {
+      overall: 0,
+      frequency: 0,
+      timeCost: 0,
+      crossProjectScore: 0,
+      recency: 0,
+    },
+  };
+}
+
+describe("computeReusabilityScores humanSignal term", () => {
+  const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+  it("does not add a humanSignal when no signal map is supplied", () => {
+    const topics = [makeTopic("a", ["s1"])];
+    computeReusabilityScores(topics, NOW);
+    expect(topics[0].reusabilityScore.humanSignal).toBeUndefined();
+    expect(topics[0].reusabilityScore.breakdown?.some((b) => b.signal === "humanSignal")).toBe(false);
+  });
+
+  it("folds in a humanSignal term with weight HUMAN_SIGNAL_WEIGHT", () => {
+    const topics = [makeTopic("a", ["s1"])];
+    computeReusabilityScores(topics, NOW, undefined, new Map([["s1", 1.0]]));
+    const score = topics[0].reusabilityScore;
+    expect(score.humanSignal).toBe(1);
+    const term = score.breakdown?.find((b) => b.signal === "humanSignal");
+    expect(term?.weight).toBeCloseTo(HUMAN_SIGNAL_WEIGHT, 5);
+  });
+
+  it("keeps the breakdown weights summing to ~1.0 after scaling", () => {
+    const topics = [makeTopic("a", ["s1"])];
+    computeReusabilityScores(topics, NOW, undefined, new Map([["s1", 0.8]]));
+    const total = (topics[0].reusabilityScore.breakdown ?? []).reduce((acc, b) => acc + b.weight, 0);
+    expect(total).toBeCloseTo(1.0, 5);
+  });
+
+  it("a stronger human signal yields a higher overall score, all else equal", () => {
+    // Two identical topics; only their human signal differs.
+    const low = [makeTopic("a", ["s1"])];
+    const high = [makeTopic("a", ["s1"])];
+    computeReusabilityScores(low, NOW, undefined, new Map([["s1", 0.0]]));
+    computeReusabilityScores(high, NOW, undefined, new Map([["s1", 1.0]]));
+    expect(high[0].reusabilityScore.overall).toBeGreaterThan(low[0].reusabilityScore.overall);
+  });
+});

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -18,7 +18,14 @@ import {
   type SessionInput,
   type SemanticKnowledgeGraph,
 } from "./knowledge-graph-builder.js";
-import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions } from "./skill-synthesizer.js";
+import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions, type HumanFeedbackSignal } from "./skill-synthesizer.js";
+import { computeSessionHumanSignal } from "./knowledge-graph/reusability.js";
+import {
+  readFeedbackFile,
+  computeSessionFeedbackCounts,
+  selectFlaggedTurns,
+  renderTurnSnippet,
+} from "./feedback-reader.js";
 import { evaluateSkill, toSkillEvaluation, shouldRetrySynthesis, type EvaluatorOptions } from "./skill-evaluator.js";
 import { generateSessionSummary } from "./session-summarizer.js";
 import {
@@ -47,6 +54,8 @@ export interface CliArgs {
   skipEval: boolean;
   evalModel?: string;
   evalThreshold: number;
+  useHumanFeedback: boolean;
+  feedbackFile: string;
 }
 
 /**
@@ -65,6 +74,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let skipEval = false;
   let evalModel: string | undefined;
   let evalThreshold = 60;
+  let useHumanFeedback = false;
+  let feedbackFile = path.resolve("public", "data", "feedback.json");
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--sessions-dir" && args[i + 1]) {
@@ -94,6 +105,10 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     } else if (args[i] === "--eval-threshold" && args[i + 1]) {
       const raw = parseInt(args[++i], 10);
       evalThreshold = Number.isNaN(raw) ? 60 : Math.min(100, Math.max(0, raw));
+    } else if (args[i] === "--use-human-feedback") {
+      useHumanFeedback = true;
+    } else if (args[i] === "--feedback-file" && args[i + 1]) {
+      feedbackFile = path.resolve(args[++i]);
     }
   }
   return {
@@ -107,6 +122,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     skipEval,
     evalModel,
     evalThreshold,
+    useHumanFeedback,
+    feedbackFile,
   };
 }
 
@@ -284,6 +301,8 @@ interface SynthesisConfig {
   skipEval?: boolean;
   evalModel?: string;
   evalThreshold?: number;
+  useHumanFeedback?: boolean;
+  feedbackFile?: string;
 }
 
 async function generateOverview(sessions: ParsedSession[], synthesisConfig: SynthesisConfig = { skip: false, count: 5 }): Promise<OverviewJson> {
@@ -446,8 +465,23 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
       subagentCount: s.meta.subagentCount,
     },
   }));
+  // Human feedback (issue #24): gated behind --use-human-feedback (default OFF).
+  // localStorage is synced to public/data/feedback.json by the skill-server.
+  const humanFeedbackMap = synthesisConfig.useHumanFeedback
+    ? readFeedbackFile(synthesisConfig.feedbackFile ?? path.resolve("public", "data", "feedback.json"))
+    : new Map();
+  const humanSignalMap = new Map<string, number>();
+  if (synthesisConfig.useHumanFeedback) {
+    for (const [sessionId, counts] of computeSessionFeedbackCounts(humanFeedbackMap)) {
+      humanSignalMap.set(sessionId, computeSessionHumanSignal(counts));
+    }
+    console.error(`[crune] Human feedback: ${humanFeedbackMap.size} sessions with bookmarks/tags/notes`);
+  }
+  const sessionInputMap = new Map(sessionInputs.map((s) => [s.sessionId, s]));
+
   const knowledgeGraph = buildSemanticKnowledgeGraph(sessionInputs, {
     facetsDir: synthesisConfig.facetsDir,
+    humanSignalMap: synthesisConfig.useHumanFeedback ? humanSignalMap : undefined,
   });
 
   // Top files
@@ -562,11 +596,28 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
         ? aggregateFacetsForTopic(topic.sessionIds, readFacetsDir(synthesisConfig.facetsDir))
         : undefined;
 
+      // Human-flagged moments for this topic (issue #24), only when enabled.
+      let humanFeedback: HumanFeedbackSignal[] | undefined;
+      if (synthesisConfig.useHumanFeedback && humanFeedbackMap.size > 0) {
+        const flagged = selectFlaggedTurns(humanFeedbackMap, topic.sessionIds);
+        if (flagged.length > 0) {
+          humanFeedback = flagged.map((f) => ({
+            sessionId: f.sessionId,
+            turnId: f.turnId,
+            snippet: renderTurnSnippet(sessionInputMap, f.sessionId, f.turnId),
+            note: f.note,
+            reusable: f.reusable,
+            antiPattern: f.antiPattern,
+          }));
+        }
+      }
+
       const prompt = buildSynthesisPrompt({
         skillCandidate: candidate,
         topicNode: topic as unknown as import("./skill-synthesizer.js").TopicNode,
         enrichedSequences: relatedSequences,
         facetsInsights: facetsInsights as unknown as import("./skill-synthesizer.js").FacetsInsightsSummary | undefined,
+        humanFeedback,
       });
       const result = await synthesizeWithClaude(prompt, synthOpts);
       if (result.success) {
@@ -669,7 +720,7 @@ function getWeekLabel(date: Date): string {
 // ─── Main Pipeline ──────────────────────────────────────────────────────────
 
 async function main() {
-  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel, evalThreshold } = parseArgs();
+  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel, evalThreshold, useHumanFeedback, feedbackFile } = parseArgs();
 
   console.error(`[crune] Sessions dir: ${sessionsDir}`);
   console.error(`[crune] Output dir:   ${outputDir}`);
@@ -794,6 +845,8 @@ async function main() {
     skipEval,
     evalModel,
     evalThreshold,
+    useHumanFeedback,
+    feedbackFile,
   });
   const overviewPath = path.join(outputDir, "overview.json");
   fs.writeFileSync(overviewPath, JSON.stringify(overviewData, null, 2));

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -1,0 +1,188 @@
+/**
+ * Pipeline-side reader for human playback feedback (bookmarks / tags / notes).
+ *
+ * The browser writes feedback to localStorage and best-effort syncs it to the
+ * skill-server, which persists it to `public/data/feedback.json` shaped
+ * `Record<sessionId, FeedbackEntry[]>`. This module reads that file back into a
+ * Map for the synthesis pipeline and renders SHORT turn snippets (signal, not
+ * transcript) for the LLM prompt.
+ *
+ * `FeedbackEntry` is mirrored here (rather than imported from `src/`) so the
+ * scripts/ build has no dependency on the frontend tsconfig. Keep in sync with
+ * `src/types/session.ts`.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import type { SessionInput } from "./knowledge-graph/types.js";
+
+export interface FeedbackEntry {
+  sessionId: string;
+  /** Numeric ConversationTurn.turnIndex; indexes into SessionInput.turns. */
+  turnId: number;
+  /** Tool-call block id (toolUseId) for block-level feedback; absent = turn-level. */
+  blockId?: string;
+  bookmarked: boolean;
+  tags: string[];
+  note: string;
+}
+
+export type FeedbackBlob = Record<string, FeedbackEntry[]>;
+
+/** Meaningful tag constants — kept identical to src/.../tagSemantics. */
+export const REUSABLE_TAG = "reusable";
+export const ANTI_PATTERN_TAG = "anti-pattern";
+
+/** True when an entry carries no signal (mirrors the browser store's pruning). */
+function isEmptyEntry(entry: FeedbackEntry): boolean {
+  return !entry.bookmarked && entry.tags.length === 0 && entry.note.trim() === "";
+}
+
+/** Coerce a raw stored value into a well-formed FeedbackEntry, or null. */
+function normalizeEntry(raw: unknown): FeedbackEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const e = raw as Record<string, unknown>;
+  if (typeof e.sessionId !== "string" || typeof e.turnId !== "number") return null;
+  const entry: FeedbackEntry = {
+    sessionId: e.sessionId,
+    turnId: e.turnId,
+    bookmarked: !!e.bookmarked,
+    tags: Array.isArray(e.tags) ? e.tags.filter((t): t is string => typeof t === "string") : [],
+    note: typeof e.note === "string" ? e.note : "",
+  };
+  if (typeof e.blockId === "string") entry.blockId = e.blockId;
+  return entry;
+}
+
+/**
+ * Normalize a raw parsed blob: keep only valid, non-empty entries; drop empty
+ * session buckets. Tolerant of malformed input (returns {} on the wrong shape).
+ */
+export function normalizeFeedbackBlob(parsed: unknown): FeedbackBlob {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const blob: FeedbackBlob = {};
+  for (const [sessionId, entries] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!Array.isArray(entries)) continue;
+    const normalized = entries
+      .map(normalizeEntry)
+      .filter((e): e is FeedbackEntry => e !== null && !isEmptyEntry(e));
+    if (normalized.length > 0) blob[sessionId] = normalized;
+  }
+  return blob;
+}
+
+/**
+ * Merge one session's posted entries into an existing blob, normalizing and
+ * dropping empties. An empty (or all-empty) `entries` clears the bucket.
+ * Returns a new blob (does not mutate the input).
+ */
+export function mergeFeedbackBlob(
+  current: FeedbackBlob,
+  sessionId: string,
+  entries: unknown[],
+): FeedbackBlob {
+  const next: FeedbackBlob = { ...current };
+  const normalized = entries
+    .map(normalizeEntry)
+    .filter((e): e is FeedbackEntry => e !== null && !isEmptyEntry(e))
+    .map((e) => ({ ...e, sessionId }));
+  if (normalized.length > 0) {
+    next[sessionId] = normalized;
+  } else {
+    delete next[sessionId];
+  }
+  return next;
+}
+
+/**
+ * Read `public/data/feedback.json` into a Map. Returns an empty Map when the
+ * file is absent or unreadable (offline / no feedback yet — never throws).
+ */
+export function readFeedbackFile(
+  filePath: string,
+): Map<string, FeedbackEntry[]> {
+  if (!existsSync(filePath)) return new Map();
+  try {
+    const blob = normalizeFeedbackBlob(JSON.parse(readFileSync(filePath, "utf-8")));
+    return new Map(Object.entries(blob));
+  } catch {
+    return new Map();
+  }
+}
+
+// ─── Turn selection helpers ──────────────────────────────────────────────────
+
+export interface FlaggedTurn {
+  sessionId: string;
+  turnId: number;
+  note: string;
+  tags: string[];
+  /** True when tagged `reusable` — VALUABLE evidence to replicate. */
+  reusable: boolean;
+  /** True when tagged `anti-pattern` — counter-example to avoid. */
+  antiPattern: boolean;
+}
+
+function tagSetHas(entry: FeedbackEntry, tag: string): boolean {
+  return entry.tags.some((t) => t.toLowerCase() === tag);
+}
+
+/**
+ * Select human-flagged turns for the given sessions. A turn qualifies when it is
+ * bookmarked OR carries a meaningful tag (`reusable` / `anti-pattern`). Returns
+ * one FlaggedTurn per qualifying entry, ordered by sessionId then turnId.
+ */
+export function selectFlaggedTurns(
+  feedback: Map<string, FeedbackEntry[]>,
+  sessionIds: Iterable<string>,
+): FlaggedTurn[] {
+  const flagged: FlaggedTurn[] = [];
+  for (const sessionId of sessionIds) {
+    const entries = feedback.get(sessionId);
+    if (!entries) continue;
+    for (const entry of entries) {
+      const reusable = tagSetHas(entry, REUSABLE_TAG);
+      const antiPattern = tagSetHas(entry, ANTI_PATTERN_TAG);
+      if (!entry.bookmarked && !reusable && !antiPattern) continue;
+      flagged.push({
+        sessionId,
+        turnId: entry.turnId,
+        note: entry.note,
+        tags: entry.tags,
+        reusable,
+        antiPattern,
+      });
+    }
+  }
+  flagged.sort((a, b) =>
+    a.sessionId === b.sessionId ? a.turnId - b.turnId : a.sessionId < b.sessionId ? -1 : 1,
+  );
+  return flagged;
+}
+
+/**
+ * Render a SHORT snippet for a (sessionId, turnId) from the session's turns:
+ * `userPrompt` plus the first `assistantText`, each truncated. Signal, not a
+ * transcript. Returns null when the session/turn is unknown.
+ */
+export function renderTurnSnippet(
+  sessions: Map<string, SessionInput>,
+  sessionId: string,
+  turnId: number,
+  maxLen = 160,
+): string | null {
+  const session = sessions.get(sessionId);
+  if (!session) return null;
+  const turn = session.turns[turnId];
+  if (!turn) return null;
+
+  const parts: string[] = [];
+  const prompt = truncate(turn.userPrompt?.trim() ?? "", maxLen);
+  if (prompt) parts.push(`User: ${prompt}`);
+  const assistant = truncate((turn.assistantTexts?.[0] ?? "").trim(), maxLen);
+  if (assistant) parts.push(`Claude: ${assistant}`);
+  return parts.length > 0 ? parts.join(" / ") : null;
+}
+
+function truncate(text: string, maxLen: number): string {
+  const collapsed = text.replace(/\s+/g, " ");
+  return collapsed.length <= maxLen ? collapsed : collapsed.slice(0, maxLen - 1) + "…";
+}

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -186,3 +186,36 @@ function truncate(text: string, maxLen: number): string {
   const collapsed = text.replace(/\s+/g, " ");
   return collapsed.length <= maxLen ? collapsed : collapsed.slice(0, maxLen - 1) + "…";
 }
+
+// ─── Reusability signal aggregation ──────────────────────────────────────────
+
+/** Per-session feedback counts used to derive a human reusability signal. */
+export interface SessionFeedbackCounts {
+  bookmarked: boolean;
+  reusableCount: number;
+  antiPatternCount: number;
+}
+
+/**
+ * Aggregate each session's feedback into bookmark / reusable / anti-pattern
+ * counts. Only sessions with at least one such signal appear in the result.
+ */
+export function computeSessionFeedbackCounts(
+  feedback: Map<string, FeedbackEntry[]>,
+): Map<string, SessionFeedbackCounts> {
+  const counts = new Map<string, SessionFeedbackCounts>();
+  for (const [sessionId, entries] of feedback) {
+    let bookmarked = false;
+    let reusableCount = 0;
+    let antiPatternCount = 0;
+    for (const entry of entries) {
+      if (entry.bookmarked) bookmarked = true;
+      if (tagSetHas(entry, REUSABLE_TAG)) reusableCount++;
+      if (tagSetHas(entry, ANTI_PATTERN_TAG)) antiPatternCount++;
+    }
+    if (bookmarked || reusableCount > 0 || antiPatternCount > 0) {
+      counts.set(sessionId, { bookmarked, reusableCount, antiPatternCount });
+    }
+  }
+  return counts;
+}

--- a/scripts/knowledge-graph/index.ts
+++ b/scripts/knowledge-graph/index.ts
@@ -79,7 +79,8 @@ export {
   findCommonPathPrefix,
 } from "./edges.js";
 export { louvainDetection, brandesBetweenness } from "./community.js";
-export { computeReusabilityScores } from "./reusability.js";
+export { computeReusabilityScores, computeSessionHumanSignal, aggregateHumanSignal, HUMAN_SIGNAL_WEIGHT } from "./reusability.js";
+export type { SessionHumanSignal } from "./reusability.js";
 export { abstractToolCall, extractEnrichedSequences } from "./tool-pattern.js";
 export { generateSkillMarkdown, generateHookJson, generateSkillCandidates } from "./skill-generator.js";
 export { readFacetsDir, normalizeGoalCategory, helpfulnessToScore, aggregateFacetsForTopic } from "./facets-reader.js";
@@ -90,7 +91,7 @@ export function buildSemanticKnowledgeGraph(
   sessions: SessionInput[],
   options: KnowledgeGraphOptions = {}
 ): SemanticKnowledgeGraph {
-  const { enableLouvain = true, enableBrandes = true, facetsDir } = options;
+  const { enableLouvain = true, enableBrandes = true, facetsDir, humanSignalMap } = options;
 
   console.error(`  [Knowledge Graph] Processing ${sessions.length} sessions...`);
 
@@ -181,7 +182,7 @@ export function buildSemanticKnowledgeGraph(
       toolIdf,
       facetsMap
     );
-    computeReusabilityScores(singleTopic, new Date(), facetsMap);
+    computeReusabilityScores(singleTopic, new Date(), facetsMap, humanSignalMap);
     const skillCandidates = generateSkillCandidates(singleTopic, enrichedSequences);
     return {
       nodes: singleTopic,
@@ -300,7 +301,7 @@ export function buildSemanticKnowledgeGraph(
   const topics = buildTopicNodes(clusterMembers, activeSessions, bm25, toolIdf, facetsMap);
 
   // Step 5b: Compute reusability scores
-  computeReusabilityScores(topics, new Date(), facetsMap);
+  computeReusabilityScores(topics, new Date(), facetsMap, humanSignalMap);
   console.error(
     `  [Knowledge Graph] Reusability scores computed for ${topics.length} topics`
   );

--- a/scripts/knowledge-graph/reusability.ts
+++ b/scripts/knowledge-graph/reusability.ts
@@ -24,6 +24,53 @@ export const FACETS_WEIGHTS = {
   helpfulness: 0.1,
 } as const;
 
+/**
+ * Weight given to the human feedback term when it is folded in (issue #24).
+ * Mirrors the per-facets weights. The remaining weights are scaled by
+ * (1 - this) so the total stays 1.0.
+ */
+export const HUMAN_SIGNAL_WEIGHT = 0.1;
+
+/** Per-session feedback counts used to derive a human signal. */
+export interface SessionHumanSignal {
+  bookmarked: boolean;
+  reusableCount: number;
+  antiPatternCount: number;
+}
+
+/**
+ * Map one session's feedback counts to a signal in [0,1]. Neutral baseline is
+ * 0.5; a bookmark nudges up, each `reusable` tag boosts further, each
+ * `anti-pattern` tag dampens. Monotonic in each lever and clamped to [0,1].
+ *
+ * Pure and deterministic so the synthesis pipeline (and tests) can reason about
+ * the signal independently of the topic-level aggregation.
+ */
+export function computeSessionHumanSignal(s: SessionHumanSignal): number {
+  let signal = 0.5;
+  if (s.bookmarked) signal += 0.15;
+  signal += 0.2 * Math.min(s.reusableCount, 3);
+  signal -= 0.2 * Math.min(s.antiPatternCount, 3);
+  return Math.max(0, Math.min(1, signal));
+}
+
+/**
+ * Aggregate per-session human signals for a topic. Sessions without feedback
+ * contribute the neutral baseline (0.5) so a single flagged session does not
+ * dominate a large cluster. Returns 0.5 for an empty topic.
+ */
+export function aggregateHumanSignal(
+  sessionIds: string[],
+  signalMap: Map<string, number>
+): number {
+  if (sessionIds.length === 0) return 0.5;
+  let sum = 0;
+  for (const sessionId of sessionIds) {
+    sum += signalMap.get(sessionId) ?? 0.5;
+  }
+  return sum / sessionIds.length;
+}
+
 type BreakdownEntry = NonNullable<ReusabilityScore["breakdown"]>[number];
 
 /**
@@ -54,7 +101,8 @@ function buildBreakdown(
 export function computeReusabilityScores(
   topics: TopicNode[],
   now: Date = new Date(),
-  facetsMap?: Map<string, FacetsData>
+  facetsMap?: Map<string, FacetsData>,
+  humanSignalMap?: Map<string, number>
 ): void {
   if (topics.length === 0) return;
 
@@ -74,6 +122,7 @@ export function computeReusabilityScores(
   const maxDays = Math.max(...daysSinceLastSeen.filter((d) => isFinite(d)), 1);
 
   const useFacets = facetsMap != null && facetsMap.size > 0;
+  const useHuman = humanSignalMap != null && humanSignalMap.size > 0;
 
   for (let i = 0; i < topics.length; i++) {
     const topic = topics[i];
@@ -98,13 +147,21 @@ export function computeReusabilityScores(
       ? 1 - days / maxDays
       : 0;
 
-    let overall: number;
     const score: ReusabilityScore = {
       overall: 0,
       frequency: Math.round(frequency * 1000) / 1000,
       timeCost: Math.round(timeCost * 1000) / 1000,
       crossProjectScore: Math.round(crossProjectScore * 1000) / 1000,
       recency: Math.round(recency * 1000) / 1000,
+    };
+
+    // Build the active weight set and matching signal values.
+    const weights: Record<string, number> = {};
+    const values: Record<string, number> = {
+      frequency,
+      timeCost,
+      crossProjectScore,
+      recency,
     };
 
     if (useFacets) {
@@ -128,42 +185,37 @@ export function computeReusabilityScores(
       const successRate = successSum / sessionCount;
       const helpfulness = helpfulnessSum / sessionCount;
 
-      overall =
-        FACETS_WEIGHTS.frequency * frequency +
-        FACETS_WEIGHTS.timeCost * timeCost +
-        FACETS_WEIGHTS.crossProjectScore * crossProjectScore +
-        FACETS_WEIGHTS.recency * recency +
-        FACETS_WEIGHTS.successRate * successRate +
-        FACETS_WEIGHTS.helpfulness * helpfulness;
+      Object.assign(weights, FACETS_WEIGHTS);
+      values.successRate = successRate;
+      values.helpfulness = helpfulness;
 
       score.successRate = Math.round(successRate * 1000) / 1000;
       score.helpfulness = Math.round(helpfulness * 1000) / 1000;
-
       score.weightProfile = "facets";
-      score.breakdown = buildBreakdown(FACETS_WEIGHTS, {
-        frequency,
-        timeCost,
-        crossProjectScore,
-        recency,
-        successRate,
-        helpfulness,
-      });
     } else {
-      overall =
-        BASE_WEIGHTS.frequency * frequency +
-        BASE_WEIGHTS.timeCost * timeCost +
-        BASE_WEIGHTS.crossProjectScore * crossProjectScore +
-        BASE_WEIGHTS.recency * recency;
-
+      Object.assign(weights, BASE_WEIGHTS);
       score.weightProfile = "base";
-      score.breakdown = buildBreakdown(BASE_WEIGHTS, {
-        frequency,
-        timeCost,
-        crossProjectScore,
-        recency,
-      });
     }
 
+    // Fold in the human feedback term (issue #24). Scale the existing weights by
+    // (1 - HUMAN_SIGNAL_WEIGHT) so the total stays 1.0 and append the new term,
+    // mirroring how facets weights make room for successRate/helpfulness.
+    if (useHuman) {
+      for (const key of Object.keys(weights)) {
+        weights[key] = weights[key] * (1 - HUMAN_SIGNAL_WEIGHT);
+      }
+      const humanSignal = aggregateHumanSignal(topic.sessionIds, humanSignalMap!);
+      weights.humanSignal = HUMAN_SIGNAL_WEIGHT;
+      values.humanSignal = humanSignal;
+      score.humanSignal = Math.round(humanSignal * 1000) / 1000;
+    }
+
+    let overall = 0;
+    for (const key of Object.keys(weights)) {
+      overall += weights[key] * (values[key] ?? 0);
+    }
+
+    score.breakdown = buildBreakdown(weights, values);
     score.overall = Math.round(overall * 1000) / 1000;
     topic.reusabilityScore = score;
   }

--- a/scripts/knowledge-graph/types.ts
+++ b/scripts/knowledge-graph/types.ts
@@ -51,6 +51,12 @@ export interface ReusabilityScore {
   recency: number;
   successRate?: number;
   helpfulness?: number;
+  /**
+   * Human feedback signal in [0,1] (issue #24): boosted by bookmarks and
+   * `reusable` tags, dampened by `anti-pattern` tags. Present only when human
+   * feedback is folded in (--use-human-feedback).
+   */
+  humanSignal?: number;
   breakdown?: {
     signal: string;
     value: number;
@@ -159,6 +165,11 @@ export interface KnowledgeGraphOptions {
   enableLouvain?: boolean;
   enableBrandes?: boolean;
   facetsDir?: string;
+  /**
+   * Per-session human feedback signal in [0,1] (issue #24). When provided and
+   * non-empty, the reusability score folds in a `humanSignal` term.
+   */
+  humanSignalMap?: Map<string, number>;
 }
 
 // ─── Internal result types ──────────────────────────────────────────────────

--- a/scripts/skill-server.ts
+++ b/scripts/skill-server.ts
@@ -1,6 +1,25 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble } from "./skill-synthesizer.js";
 import type { SynthesisRequest, SynthesisResponse } from "./skill-synthesizer.js";
+import { mergeFeedbackBlob, normalizeFeedbackBlob, type FeedbackBlob } from "./feedback-reader.js";
+
+// ---------- Constants ----------
+
+/** On-disk feedback store synced from the browser. Read by the pipeline. */
+const FEEDBACK_FILE = resolve("public", "data", "feedback.json");
+
+/**
+ * CORS headers shared by every endpoint. The Vite dev server proxies
+ * `/api/synthesize`, but the feedback sync client may also POST cross-origin,
+ * so allow it explicitly (mirrors the synthesize contract).
+ */
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
 
 // ---------- Helpers ----------
 
@@ -13,8 +32,8 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
-function sendJson(res: ServerResponse, status: number, body: SynthesisResponse | { error: string }) {
-  res.writeHead(status, { "Content-Type": "application/json" });
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+  res.writeHead(status, { "Content-Type": "application/json", ...CORS_HEADERS });
   res.end(JSON.stringify(body));
 }
 
@@ -26,12 +45,12 @@ async function handleSynthesize(req: IncomingMessage, res: ServerResponse) {
     const raw = await readBody(req);
     body = JSON.parse(raw);
   } catch {
-    sendJson(res, 400, { success: false, error: "Invalid JSON in request body" });
+    sendJson(res, 400, { success: false, error: "Invalid JSON in request body" } satisfies SynthesisResponse);
     return;
   }
 
   if (!body.skillCandidate || !body.topicNode) {
-    sendJson(res, 400, { success: false, error: "Missing required fields: skillCandidate, topicNode" });
+    sendJson(res, 400, { success: false, error: "Missing required fields: skillCandidate, topicNode" } satisfies SynthesisResponse);
     return;
   }
 
@@ -39,11 +58,60 @@ async function handleSynthesize(req: IncomingMessage, res: ServerResponse) {
   const result = await synthesizeWithClaude(prompt);
 
   if (!result.success) {
-    sendJson(res, 500, { success: false, error: result.error });
+    sendJson(res, 500, { success: false, error: result.error } satisfies SynthesisResponse);
     return;
   }
 
-  sendJson(res, 200, { success: true, synthesizedMarkdown: stripSynthesisPreamble(result.stdout) });
+  sendJson(res, 200, { success: true, synthesizedMarkdown: stripSynthesisPreamble(result.stdout) } satisfies SynthesisResponse);
+}
+
+/** Read the on-disk feedback map (normalized), or {} if absent/corrupt. */
+function readFeedbackFile(): FeedbackBlob {
+  if (!existsSync(FEEDBACK_FILE)) return {};
+  try {
+    const raw = readFileSync(FEEDBACK_FILE, "utf-8");
+    return normalizeFeedbackBlob(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+function writeFeedbackFile(blob: FeedbackBlob): void {
+  mkdirSync(dirname(FEEDBACK_FILE), { recursive: true });
+  writeFileSync(FEEDBACK_FILE, JSON.stringify(blob, null, 2), "utf-8");
+}
+
+function handleGetFeedback(res: ServerResponse) {
+  sendJson(res, 200, readFeedbackFile());
+}
+
+/**
+ * Merge the posted session's entries into the on-disk feedback map. The body is
+ * `{ sessionId, entries }`; an empty `entries` array clears that session's
+ * bucket. Normalization (dropping empty entries) mirrors the browser store.
+ */
+async function handlePostFeedback(req: IncomingMessage, res: ServerResponse) {
+  let body: { sessionId?: unknown; entries?: unknown };
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch {
+    sendJson(res, 400, { error: "Invalid JSON in request body" });
+    return;
+  }
+
+  if (typeof body.sessionId !== "string" || !Array.isArray(body.entries)) {
+    sendJson(res, 400, { error: "Missing required fields: sessionId, entries" });
+    return;
+  }
+
+  try {
+    const current = readFeedbackFile();
+    const merged = mergeFeedbackBlob(current, body.sessionId, body.entries);
+    writeFeedbackFile(merged);
+    sendJson(res, 200, { ok: true });
+  } catch (err) {
+    sendJson(res, 500, { error: err instanceof Error ? err.message : "Failed to persist feedback" });
+  }
 }
 
 // ---------- Server ----------
@@ -54,8 +122,17 @@ if (isDirectRun) {
   const PORT = 3456;
 
   const server = createServer(async (req, res) => {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, CORS_HEADERS);
+      res.end();
+      return;
+    }
     if (req.method === "POST" && req.url === "/api/synthesize") {
       await handleSynthesize(req, res);
+    } else if (req.method === "GET" && req.url === "/api/feedback") {
+      handleGetFeedback(res);
+    } else if (req.method === "POST" && req.url === "/api/feedback") {
+      await handlePostFeedback(req, res);
     } else {
       sendJson(res, 404, { error: "Not found" });
     }

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -302,7 +302,7 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
   const humanFeedbackSection = buildHumanFeedbackSection(humanFeedback ?? []);
   if (humanFeedbackSection) {
     instructionLines.push(
-      `${nextRule++}. Prioritize the **Human-Flagged Moments** above: replicate the \`reusable\` approaches and explicitly steer away from the \`anti-pattern\` ones. These are direct human signals and outrank heuristic inferences.`,
+      `${nextRule}. Prioritize the **Human-Flagged Moments** above: replicate the \`reusable\` approaches and explicitly steer away from the \`anti-pattern\` ones. These are direct human signals and outrank heuristic inferences.`,
     );
   }
 

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -71,12 +71,31 @@ export interface FacetsInsightsSummary {
   frictionDetails: string[];
 }
 
+/**
+ * A human-flagged playback moment threaded into synthesis (issue #24). The
+ * caller resolves a short snippet for the turn; this module only formats it.
+ */
+export interface HumanFeedbackSignal {
+  sessionId: string;
+  turnId: number;
+  /** Short turn snippet (userPrompt + first assistant text), or null if unknown. */
+  snippet: string | null;
+  /** User's freeform note for the turn, if any. */
+  note: string;
+  /** Tagged `reusable` — VALUABLE evidence to replicate. */
+  reusable: boolean;
+  /** Tagged `anti-pattern` — counter-example to avoid. */
+  antiPattern: boolean;
+}
+
 export interface SynthesisRequest {
   skillCandidate: SkillCandidate;
   topicNode: TopicNode;
   enrichedSequences?: EnrichedSequence[];
   graphContext?: GraphContext;
   facetsInsights?: FacetsInsightsSummary;
+  /** Human-flagged moments (issue #24); present only with --use-human-feedback. */
+  humanFeedback?: HumanFeedbackSignal[];
 }
 
 export interface SynthesisResponse {
@@ -87,8 +106,55 @@ export interface SynthesisResponse {
 
 // ---------- Prompt Builder ----------
 
+/**
+ * Render the "Human-Flagged Moments" section from explicit user feedback.
+ * `reusable` turns are framed as VALUABLE evidence to replicate, `anti-pattern`
+ * turns as counter-examples to avoid, and bare bookmarks as noteworthy moments.
+ * Returns "" when there is nothing to report.
+ */
+export function buildHumanFeedbackSection(signals: HumanFeedbackSignal[]): string {
+  if (!signals || signals.length === 0) return "";
+
+  const reusable = signals.filter((s) => s.reusable);
+  const antiPattern = signals.filter((s) => s.antiPattern);
+  // Bookmarked-only: flagged but without a meaningful tag.
+  const noteworthy = signals.filter((s) => !s.reusable && !s.antiPattern);
+
+  const render = (s: HumanFeedbackSignal): string => {
+    const body = s.snippet ?? "(snippet unavailable)";
+    const note = s.note.trim() ? ` — note: ${s.note.trim()}` : "";
+    return `- ${body}${note}`;
+  };
+
+  const lines = [`## Human-Flagged Moments (explicit user feedback)`];
+
+  if (reusable.length > 0) {
+    lines.push(
+      "### Reusable (VALUABLE — replicate this in the skill)",
+      "These moments were marked by a human as worth reusing. Treat them as strong positive evidence and reflect their approach in the workflow steps.",
+      ...reusable.map(render),
+    );
+  }
+  if (antiPattern.length > 0) {
+    lines.push(
+      "### Anti-Pattern (AVOID — counter-example)",
+      "These moments were marked by a human as things to avoid. Do NOT recommend this approach; where relevant, add explicit guidance steering away from it.",
+      ...antiPattern.map(render),
+    );
+  }
+  if (noteworthy.length > 0) {
+    lines.push(
+      "### Bookmarked (noteworthy)",
+      "These moments were bookmarked as noteworthy. Consider them when shaping the skill.",
+      ...noteworthy.map(render),
+    );
+  }
+
+  return lines.join("\n");
+}
+
 export function buildSynthesisPrompt(body: SynthesisRequest): string {
-  const { skillCandidate, topicNode, enrichedSequences, graphContext, facetsInsights } = body;
+  const { skillCandidate, topicNode, enrichedSequences, graphContext, facetsInsights, humanFeedback } = body;
 
   const topicInfo = [
     `## Topic Information`,
@@ -226,8 +292,18 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     `7. Output ONLY the markdown content. No code fences wrapping the output, no explanations before or after.`,
   ];
 
+  // Rules 1-7 are fixed; additional conditional rules are numbered sequentially.
+  let nextRule = 8;
   if (graphContext && graphContext.connectedTopics.some(ct => ct.edgeType === "workflow-continuation")) {
-    instructionLines.push(`8. If workflow-continuation connections exist, include \`requires\` and/or \`next\` fields in the YAML frontmatter listing the connected topic labels.`);
+    instructionLines.push(`${nextRule++}. If workflow-continuation connections exist, include \`requires\` and/or \`next\` fields in the YAML frontmatter listing the connected topic labels.`);
+  }
+
+  // --- Human-flagged moments section (issue #24) ---
+  const humanFeedbackSection = buildHumanFeedbackSection(humanFeedback ?? []);
+  if (humanFeedbackSection) {
+    instructionLines.push(
+      `${nextRule++}. Prioritize the **Human-Flagged Moments** above: replicate the \`reusable\` approaches and explicitly steer away from the \`anti-pattern\` ones. These are direct human signals and outrank heuristic inferences.`,
+    );
   }
 
   const instruction = instructionLines.join("\n");
@@ -253,7 +329,7 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     facetsSection = lines.join("\n");
   }
 
-  const parts = [topicInfo, prompts, toolSig, toolPatterns, graphPosition, connectedTopicsSection, facetsSection, reference, instruction].filter(Boolean);
+  const parts = [topicInfo, prompts, toolSig, toolPatterns, graphPosition, connectedTopicsSection, facetsSection, humanFeedbackSection, reference, instruction].filter(Boolean);
   return parts.join("\n\n");
 }
 

--- a/src/components/playback/__tests__/tagSemantics.test.ts
+++ b/src/components/playback/__tests__/tagSemantics.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import {
+  REUSABLE_TAG,
+  ANTI_PATTERN_TAG,
+  SEMANTIC_TAGS,
+  SEMANTIC_TAG_HINTS,
+  isSemanticTag,
+} from '../feedback/tagSemantics'
+
+describe('tagSemantics', () => {
+  it('exposes the two meaningful tags', () => {
+    expect(REUSABLE_TAG).toBe('reusable')
+    expect(ANTI_PATTERN_TAG).toBe('anti-pattern')
+    expect(SEMANTIC_TAGS).toEqual([REUSABLE_TAG, ANTI_PATTERN_TAG])
+  })
+
+  it('provides a hint for every semantic tag', () => {
+    for (const tag of SEMANTIC_TAGS) {
+      expect(SEMANTIC_TAG_HINTS[tag]).toBeTruthy()
+    }
+  })
+
+  describe('isSemanticTag', () => {
+    it('classifies the meaningful tags (case-insensitive)', () => {
+      expect(isSemanticTag('reusable')).toBe(true)
+      expect(isSemanticTag('Reusable')).toBe(true)
+      expect(isSemanticTag('ANTI-PATTERN')).toBe(true)
+    })
+
+    it('rejects free-text tags', () => {
+      expect(isSemanticTag('important')).toBe(false)
+      expect(isSemanticTag('')).toBe(false)
+      expect(isSemanticTag('reusable ')).toBe(false)
+    })
+  })
+})

--- a/src/components/playback/feedback/TagInput.tsx
+++ b/src/components/playback/feedback/TagInput.tsx
@@ -1,4 +1,5 @@
-import { useId, useState } from 'react'
+import { useId, useMemo, useState } from 'react'
+import { SEMANTIC_TAGS } from './tagSemantics'
 
 interface Props {
   /** Existing tags on the entry. */
@@ -12,10 +13,21 @@ interface Props {
 /**
  * Controlled tag editor with native <datalist> autocomplete. Submits the
  * current value on Enter, deduping is handled upstream by the store.
+ *
+ * The two meaningful tags (`reusable` / `anti-pattern`) are always offered
+ * first so users can flag turns for the synthesis pipeline without recalling
+ * the exact spelling.
  */
 export function TagInput({ tags, suggestions, onAdd, onRemove }: Props) {
   const [value, setValue] = useState('')
   const listId = useId()
+
+  // Surface the semantic tags first, then any other known tags (deduped).
+  const options = useMemo(() => {
+    const seen = new Set<string>(SEMANTIC_TAGS)
+    const rest = suggestions.filter(s => !seen.has(s))
+    return [...SEMANTIC_TAGS, ...rest]
+  }, [suggestions])
 
   const commit = () => {
     const clean = value.trim()
@@ -56,7 +68,7 @@ export function TagInput({ tags, suggestions, onAdd, onRemove }: Props) {
         onBlur={commit}
       />
       <datalist id={listId}>
-        {suggestions.map(s => (
+        {options.map(s => (
           <option key={s} value={s} />
         ))}
       </datalist>

--- a/src/components/playback/feedback/feedbackSync.ts
+++ b/src/components/playback/feedback/feedbackSync.ts
@@ -1,0 +1,39 @@
+/**
+ * Best-effort bridge that mirrors a session's feedback to the local skill-server
+ * so the offline pipeline can read it from `public/data/feedback.json`.
+ *
+ * localStorage remains the offline source of truth; this sync is purely additive
+ * and MUST NOT block the UI or surface errors. Every failure (server down,
+ * offline, CORS) is swallowed — the dashboard works without the server running.
+ *
+ * Mirrors the `/api/synthesize` client contract: a relative `/api/feedback` URL
+ * proxied by Vite in dev to `localhost:3456`.
+ */
+import type { FeedbackEntry } from '../../../types'
+
+const FEEDBACK_SYNC_URL = '/api/feedback'
+
+/**
+ * Fire-and-forget POST of one session's entries to the skill-server. Resolves
+ * (never rejects) regardless of outcome so callers can ignore the result.
+ * An empty `entries` array clears the session's bucket on disk.
+ */
+export function syncSessionFeedback(
+  sessionId: string,
+  entries: FeedbackEntry[],
+): void {
+  if (typeof fetch !== 'function') return
+  try {
+    void fetch(FEEDBACK_SYNC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, entries }),
+      // Keep the request alive even if the user navigates away mid-flight.
+      keepalive: true,
+    }).catch(() => {
+      // Offline / server not running — localStorage already has the truth.
+    })
+  } catch {
+    // Synchronous throw (e.g. fetch unavailable) — ignore.
+  }
+}

--- a/src/components/playback/feedback/tagSemantics.ts
+++ b/src/components/playback/feedback/tagSemantics.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared semantics for the two meaningful feedback tags. Tags are free-text,
+ * but these two carry a defined meaning that the synthesis pipeline acts on:
+ *
+ *   - `reusable`     → this turn is VALUABLE evidence to replicate in a skill.
+ *   - `anti-pattern` → this turn is a counter-example; skills should avoid it.
+ *
+ * Keep these constants in sync with `scripts/feedback-reader.ts`
+ * (REUSABLE_TAG / ANTI_PATTERN_TAG), which the pipeline reads independently of
+ * the frontend build.
+ */
+
+export const REUSABLE_TAG = 'reusable'
+export const ANTI_PATTERN_TAG = 'anti-pattern'
+
+/** The meaningful tags, surfaced as suggestions in the tag editor. */
+export const SEMANTIC_TAGS = [REUSABLE_TAG, ANTI_PATTERN_TAG] as const
+
+export type SemanticTag = (typeof SEMANTIC_TAGS)[number]
+
+/** Human-readable hint (Japanese UI) for each semantic tag. */
+export const SEMANTIC_TAG_HINTS: Record<SemanticTag, string> = {
+  [REUSABLE_TAG]: 'スキル合成で再現したい良い手順',
+  [ANTI_PATTERN_TAG]: 'スキル合成で避けるべき反面教師',
+}
+
+/** True when `tag` is one of the meaningful tags (case-insensitive). */
+export function isSemanticTag(tag: string): tag is SemanticTag {
+  const lower = tag.toLowerCase()
+  return SEMANTIC_TAGS.some(t => t === lower)
+}

--- a/src/hooks/useSessionFeedback.ts
+++ b/src/hooks/useSessionFeedback.ts
@@ -10,6 +10,7 @@ import {
   setNote as storeSetNote,
   toggleBookmark as storeToggleBookmark,
 } from '../components/playback/feedback/feedbackStore'
+import { syncSessionFeedback } from '../components/playback/feedback/feedbackSync'
 
 /**
  * React binding over the pure feedbackStore, scoped to one session.
@@ -17,10 +18,23 @@ import {
  * The store itself is the source of truth (localStorage); this hook keeps a
  * `version` counter that is bumped after every mutation so consuming
  * components re-render. Returns a value shaped for FeedbackContext.
+ *
+ * After every mutation the session's entries are also best-effort mirrored to
+ * the skill-server (`syncSessionFeedback`) so the offline pipeline can read
+ * them. The sync is fire-and-forget and never blocks the UI.
  */
 export function useSessionFeedback(sessionId: string | null): FeedbackContextValue {
   const [version, setVersion] = useState(0)
-  const bump = useCallback(() => setVersion(v => v + 1), [])
+
+  // Bump the re-render counter, then mirror the freshly-persisted entries to
+  // the skill-server. Reading from the store (not local state) guarantees we
+  // POST exactly what is on disk, including the store's empty-entry pruning.
+  const commit = useCallback(() => {
+    setVersion(v => v + 1)
+    if (sessionId) {
+      syncSessionFeedback(sessionId, loadSessionFeedback(sessionId))
+    }
+  }, [sessionId])
 
   // Parse the current session's feedback blob exactly once per mutation and
   // index it by entryKey, so per-block/per-turn lookups during a render are
@@ -45,36 +59,36 @@ export function useSessionFeedback(sessionId: string | null): FeedbackContextVal
     (turnId: number, blockId?: string) => {
       if (!sessionId) return
       storeToggleBookmark(sessionId, turnId, blockId)
-      bump()
+      commit()
     },
-    [sessionId, bump],
+    [sessionId, commit],
   )
 
   const addTag = useCallback(
     (turnId: number, blockId: string | undefined, tag: string) => {
       if (!sessionId) return
       storeAddTag(sessionId, turnId, blockId, tag)
-      bump()
+      commit()
     },
-    [sessionId, bump],
+    [sessionId, commit],
   )
 
   const removeTag = useCallback(
     (turnId: number, blockId: string | undefined, tag: string) => {
       if (!sessionId) return
       storeRemoveTag(sessionId, turnId, blockId, tag)
-      bump()
+      commit()
     },
-    [sessionId, bump],
+    [sessionId, commit],
   )
 
   const setNote = useCallback(
     (turnId: number, blockId: string | undefined, note: string) => {
       if (!sessionId) return
       storeSetNote(sessionId, turnId, blockId, note)
-      bump()
+      commit()
     },
-    [sessionId, bump],
+    [sessionId, commit],
   )
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- recompute when feedback changes

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -141,6 +141,12 @@ export interface ReusabilityScore {
   recency: number
   successRate?: number
   helpfulness?: number
+  /**
+   * Human feedback signal in [0,1] (issue #24): boosted by bookmarks and
+   * `reusable` tags, dampened by `anti-pattern` tags. Present only when human
+   * feedback is folded in (--use-human-feedback).
+   */
+  humanSignal?: number
   breakdown?: {
     signal: string
     value: number

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api/synthesize': 'http://localhost:3456',
+      '/api/feedback': 'http://localhost:3456',
     },
   },
 })


### PR DESCRIPTION
Closes #24 (Wave 3 — Feedback loop).

## Why
Bookmarks / tags / notes collected via #23 are the strongest human signal about *which moments are actually reusable*, but they lived only in browser `localStorage` and the synthesis pipeline never saw them.

## What
1. **Persistence bridge (skill-server auto-sync)** — `skill-server` gains `GET/POST /api/feedback` persisting the browser's feedback to `public/data/feedback.json` (shared CORS, OPTIONS preflight, gitignored runtime file). The UI best-effort fire-and-forget syncs each session's entries after every mutation via new `feedbackSync.ts` wired through `useSessionFeedback` (offline still works; localStorage stays the source of truth). `vite.config.ts` proxies `/api/feedback` → :3456.
2. **Tag semantics** — shared `reusable` / `anti-pattern` constants (`src/.../tagSemantics.ts`, mirrored in `scripts/feedback-reader.ts`), surfaced first in the `TagInput` datalist, documented in CLAUDE.md.
3. **Pipeline reader** — new `scripts/feedback-reader.ts` parses the on-disk map, selects bookmarked / reusable / anti-pattern turns, and renders short signal snippets.
4. **Synthesis prompt** — `buildSynthesisPrompt` gains an optional *Human-Flagged Moments* section (`reusable` = replicate, `anti-pattern` = avoid), threaded via `SynthesisRequest.humanFeedback`.
5. **Reusability score** — optional `humanSignal` term (weight 0.10, monotonic: boosts on bookmarks/reusable, dampens on anti-pattern) folded in alongside `successRate`/`helpfulness`.

## A/B gating
Entire feature is **OFF** unless `--use-human-feedback` is passed to `analyze-sessions` (+ `--feedback-file <path>` override). Default behavior and all existing tests are unchanged. Self-contained — no dependency on the RAG work (#32).

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ 609/609 (41 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)