### PR TITLE
refactor: address /nirami + /code-review feedback on Wave A (#24/#32/#35)

### DIFF
--- a/scripts/__tests__/bm25.test.ts
+++ b/scripts/__tests__/bm25.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from "vitest";
 import { buildBm25 } from "../knowledge-graph-builder.js";
 
 describe("buildBm25", () => {
+  it("admits single-document terms when minDf=1 (turn-level retrieval)", () => {
+    const documents = new Map<string, string[]>();
+    documents.set("doc1", ["alpha", "beta", "gamma"]);
+    documents.set("doc2", ["alpha", "beta", "delta"]);
+    // Default (minDf=2) drops the df==1 terms...
+    expect(buildBm25(documents).vocabulary).not.toContain("gamma");
+    // ...minDf=1 keeps them so the sparse channel isn't inert on short docs.
+    const vocab = buildBm25(documents, 1).vocabulary;
+    expect(vocab).toContain("gamma");
+    expect(vocab).toContain("delta");
+    // A term in EVERY doc is still excluded by the maxDf cap.
+    expect(vocab).not.toContain("alpha");
+  });
+
   it("excludes terms that appear in only 1 document", () => {
     const documents = new Map<string, string[]>();
     documents.set("doc1", ["alpha", "beta", "gamma"]);

--- a/scripts/__tests__/embedding-io.test.ts
+++ b/scripts/__tests__/embedding-io.test.ts
@@ -65,4 +65,22 @@ describe("writeEmbeddingIndex / readEmbeddingIndex", () => {
     fs.writeFileSync(metaPath, JSON.stringify(meta));
     expect(() => readEmbeddingIndex(dir)).toThrow(/size mismatch/);
   });
+
+  it("throws a clear error on a malformed meta.json (not a NaN mismatch)", () => {
+    const dir = mkTmp();
+    const result: EmbedResult = {
+      model: "m",
+      dim: 2,
+      count: 1,
+      scale: 1 / 127,
+      matrix: Int8Array.from([1, 2]),
+      chunks: [{ sessionId: "s1", turnIndex: 0, role: "user-turn", snippet: "x" }],
+    };
+    writeEmbeddingIndex(dir, result);
+    const metaPath = path.join(dir, "meta.json");
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+    delete meta.dim; // simulate an old/corrupt meta
+    fs.writeFileSync(metaPath, JSON.stringify(meta));
+    expect(() => readEmbeddingIndex(dir)).toThrow(/malformed embedding meta\.json/);
+  });
 });

--- a/scripts/__tests__/feedback-reader.test.ts
+++ b/scripts/__tests__/feedback-reader.test.ts
@@ -174,4 +174,46 @@ describe("computeSessionFeedbackCounts", () => {
     expect(counts.get("s1")).toEqual({ bookmarked: true, reusableCount: 2, antiPatternCount: 1 });
     expect(counts.has("s2")).toBe(false);
   });
+
+  it("counts a turn flagged on multiple blocks once (no block-level inflation)", () => {
+    const feedback = new Map<string, FeedbackEntry[]>([
+      [
+        "s1",
+        [
+          entry({ turnId: 5, blockId: "a", tags: [REUSABLE_TAG] }),
+          entry({ turnId: 5, blockId: "b", tags: [REUSABLE_TAG] }),
+          entry({ turnId: 5, blockId: "c", tags: [REUSABLE_TAG] }),
+        ],
+      ],
+    ]);
+    expect(computeSessionFeedbackCounts(feedback).get("s1")).toEqual({
+      bookmarked: false,
+      reusableCount: 1,
+      antiPatternCount: 0,
+    });
+  });
+});
+
+describe("selectFlaggedTurns block-level collapse", () => {
+  it("collapses multiple block entries on one turn into a single FlaggedTurn", () => {
+    const feedback = new Map<string, FeedbackEntry[]>([
+      [
+        "s1",
+        [
+          entry({ turnId: 3, blockId: "a", bookmarked: true }),
+          entry({ turnId: 3, blockId: "b", tags: [REUSABLE_TAG], note: "good" }),
+          entry({ turnId: 3, blockId: "c", tags: [ANTI_PATTERN_TAG] }),
+        ],
+      ],
+    ]);
+    const flagged = selectFlaggedTurns(feedback, ["s1"]);
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0]).toMatchObject({
+      turnId: 3,
+      reusable: true,
+      antiPattern: true,
+      note: "good",
+    });
+    expect(flagged[0].tags).toEqual([REUSABLE_TAG, ANTI_PATTERN_TAG]);
+  });
 });

--- a/scripts/__tests__/skill-server-feedback.test.ts
+++ b/scripts/__tests__/skill-server-feedback.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { mergeFeedbackPost } from "../skill-server.js";
+import type { FeedbackEntry } from "../feedback-reader.js";
+
+const tmpFiles: string[] = [];
+function tmpFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crune-feedback-"));
+  const file = path.join(dir, "feedback.json");
+  tmpFiles.push(file);
+  return file;
+}
+
+function entry(p: Partial<FeedbackEntry>): FeedbackEntry {
+  return { sessionId: "s1", turnId: 0, bookmarked: false, tags: [], note: "", ...p };
+}
+
+function read(file: string): Record<string, FeedbackEntry[]> {
+  return JSON.parse(fs.readFileSync(file, "utf-8"));
+}
+
+afterEach(() => {
+  for (const f of tmpFiles.splice(0)) {
+    fs.rmSync(path.dirname(f), { recursive: true, force: true });
+  }
+});
+
+describe("mergeFeedbackPost (skill-server persistence)", () => {
+  it("persists a session's entries as valid JSON on disk", async () => {
+    const file = tmpFile();
+    await mergeFeedbackPost("s1", [entry({ turnId: 2, bookmarked: true })], file);
+    const blob = read(file);
+    expect(blob.s1).toHaveLength(1);
+    expect(blob.s1[0]).toMatchObject({ sessionId: "s1", turnId: 2, bookmarked: true });
+  });
+
+  it("drops empty (signal-less) entries on the way in", async () => {
+    const file = tmpFile();
+    await mergeFeedbackPost("s1", [entry({ turnId: 0, note: "   " })], file);
+    expect(fs.existsSync(file)).toBe(true);
+    expect(read(file).s1).toBeUndefined();
+  });
+
+  it("an empty entries array clears that session's bucket", async () => {
+    const file = tmpFile();
+    await mergeFeedbackPost("s1", [entry({ turnId: 1, bookmarked: true })], file);
+    await mergeFeedbackPost("s1", [], file);
+    expect(read(file).s1).toBeUndefined();
+  });
+
+  it("serializes concurrent posts for different sessions without lost updates", async () => {
+    const file = tmpFile();
+    await Promise.all([
+      mergeFeedbackPost("a", [entry({ sessionId: "a", turnId: 0, bookmarked: true })], file),
+      mergeFeedbackPost("b", [entry({ sessionId: "b", turnId: 0, bookmarked: true })], file),
+      mergeFeedbackPost("c", [entry({ sessionId: "c", turnId: 0, bookmarked: true })], file),
+    ]);
+    const blob = read(file);
+    expect(Object.keys(blob).sort()).toEqual(["a", "b", "c"]);
+  });
+});

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -488,45 +488,7 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
   }
 
   // Build semantic knowledge graph
-  const sessionInputs: SessionInput[] = sessions.map((s) => ({
-    sessionId: s.meta.sessionId,
-    projectDisplayName: s.projectDisplayName,
-    turns: s.turns.map((t) => ({
-      userPrompt: t.userPrompt,
-      assistantTexts: t.assistantTexts,
-      toolCalls: t.toolCalls.map((tc) => ({
-        toolName: tc.toolName,
-        input: tc.input,
-      })),
-    })),
-    subagents: Object.fromEntries(
-      Object.entries(s.subagents).map(([id, sub]) => [
-        id,
-        {
-          agentId: sub.agentId,
-          agentType: sub.agentType,
-          turns: sub.turns.map((t) => ({
-            userPrompt: t.userPrompt,
-            assistantTexts: t.assistantTexts,
-            toolCalls: t.toolCalls.map((tc) => ({
-              toolName: tc.toolName,
-              input: tc.input,
-            })),
-          })),
-        },
-      ])
-    ),
-    meta: {
-      sessionId: s.meta.sessionId,
-      createdAt: s.meta.createdAt,
-      lastActiveAt: s.meta.lastActiveAt,
-      durationMinutes: s.meta.durationMinutes,
-      filesEdited: s.meta.filesEdited,
-      gitBranch: s.meta.gitBranch,
-      toolBreakdown: s.meta.toolBreakdown,
-      subagentCount: s.meta.subagentCount,
-    },
-  }));
+  const sessionInputs: SessionInput[] = toSessionInputs(sessions);
   // Human feedback (issue #24): gated behind --use-human-feedback (default OFF).
   // localStorage is synced to public/data/feedback.json by the skill-server.
   const humanFeedbackMap = synthesisConfig.useHumanFeedback

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -603,6 +603,11 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
     if (total > 0) {
       console.error(`[crune] Synthesizing top ${total} skill candidates${synthesisConfig.model ? ` (model: ${synthesisConfig.model})` : ""}...`);
     }
+    // Read facets once for the whole loop — the result is loop-invariant, so
+    // re-reading/re-parsing the directory per candidate was wasted I/O.
+    const facetsForSynthesis = synthesisConfig.facetsDir
+      ? readFacetsDir(synthesisConfig.facetsDir)
+      : undefined;
     for (let i = 0; i < topCandidates.length; i++) {
       const candidate = topCandidates[i];
       const topic = knowledgeGraph.nodes.find((n) => n.id === candidate.topicId);
@@ -616,8 +621,8 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
       console.error(`[crune]   [${i + 1}/${total}] ${topic.label}...`);
 
       // Build facets insights for this topic if facets data is available
-      const facetsInsights = synthesisConfig.facetsDir
-        ? aggregateFacetsForTopic(topic.sessionIds, readFacetsDir(synthesisConfig.facetsDir))
+      const facetsInsights = facetsForSynthesis
+        ? aggregateFacetsForTopic(topic.sessionIds, facetsForSynthesis)
         : undefined;
 
       // Human-flagged moments for this topic (issue #24), only when enabled.

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -12,7 +12,9 @@
  * `src/types/session.ts`.
  */
 import { existsSync, readFileSync } from "node:fs";
-import type { SessionInput } from "./knowledge-graph/types.js";
+import type { SessionInput, SessionFeedbackCounts } from "./knowledge-graph/types.js";
+
+export type { SessionFeedbackCounts };
 
 export interface FeedbackEntry {
   sessionId: string;
@@ -212,13 +214,6 @@ function truncate(text: string, maxLen: number): string {
 }
 
 // ─── Reusability signal aggregation ──────────────────────────────────────────
-
-/** Per-session feedback counts used to derive a human reusability signal. */
-export interface SessionFeedbackCounts {
-  bookmarked: boolean;
-  reusableCount: number;
-  antiPatternCount: number;
-}
 
 /**
  * Aggregate each session's feedback into bookmark / reusable / anti-pattern

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -122,7 +122,8 @@ export interface FlaggedTurn {
 }
 
 function tagSetHas(entry: FeedbackEntry, tag: string): boolean {
-  return entry.tags.some((t) => t.toLowerCase() === tag);
+  const needle = tag.toLowerCase();
+  return entry.tags.some((t) => t.toLowerCase() === needle);
 }
 
 /**

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -93,19 +93,27 @@ export function mergeFeedbackBlob(
 }
 
 /**
- * Read `public/data/feedback.json` into a Map. Returns an empty Map when the
- * file is absent or unreadable (offline / no feedback yet — never throws).
+ * Read a feedback file into a normalized blob. Returns {} when the file is
+ * absent or unreadable (offline / no feedback yet — never throws). Single source
+ * of the tolerant-read contract, shared by the pipeline and the skill-server.
+ */
+export function readFeedbackBlob(filePath: string): FeedbackBlob {
+  if (!existsSync(filePath)) return {};
+  try {
+    return normalizeFeedbackBlob(JSON.parse(readFileSync(filePath, "utf-8")));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read `public/data/feedback.json` into a Map (the pipeline's preferred shape).
+ * Thin wrapper over {@link readFeedbackBlob}.
  */
 export function readFeedbackFile(
   filePath: string,
 ): Map<string, FeedbackEntry[]> {
-  if (!existsSync(filePath)) return new Map();
-  try {
-    const blob = normalizeFeedbackBlob(JSON.parse(readFileSync(filePath, "utf-8")));
-    return new Map(Object.entries(blob));
-  } catch {
-    return new Map();
-  }
+  return new Map(Object.entries(readFeedbackBlob(filePath)));
 }
 
 // ─── Turn selection helpers ──────────────────────────────────────────────────

--- a/scripts/feedback-reader.ts
+++ b/scripts/feedback-reader.ts
@@ -128,8 +128,11 @@ function tagSetHas(entry: FeedbackEntry, tag: string): boolean {
 
 /**
  * Select human-flagged turns for the given sessions. A turn qualifies when it is
- * bookmarked OR carries a meaningful tag (`reusable` / `anti-pattern`). Returns
- * one FlaggedTurn per qualifying entry, ordered by sessionId then turnId.
+ * bookmarked OR carries a meaningful tag (`reusable` / `anti-pattern`). Multiple
+ * (block-level) entries on the same turn are collapsed into a single FlaggedTurn
+ * — unioning tags/flags and keeping the first non-empty note — so a turn flagged
+ * on several tool-call blocks is not listed (or weighted) more than once. Result
+ * is ordered by sessionId then turnId.
  */
 export function selectFlaggedTurns(
   feedback: Map<string, FeedbackEntry[]>,
@@ -139,19 +142,31 @@ export function selectFlaggedTurns(
   for (const sessionId of sessionIds) {
     const entries = feedback.get(sessionId);
     if (!entries) continue;
+    const byTurn = new Map<number, FlaggedTurn>();
     for (const entry of entries) {
       const reusable = tagSetHas(entry, REUSABLE_TAG);
       const antiPattern = tagSetHas(entry, ANTI_PATTERN_TAG);
       if (!entry.bookmarked && !reusable && !antiPattern) continue;
-      flagged.push({
-        sessionId,
-        turnId: entry.turnId,
-        note: entry.note,
-        tags: entry.tags,
-        reusable,
-        antiPattern,
-      });
+      const existing = byTurn.get(entry.turnId);
+      if (existing) {
+        existing.reusable = existing.reusable || reusable;
+        existing.antiPattern = existing.antiPattern || antiPattern;
+        for (const t of entry.tags) {
+          if (!existing.tags.includes(t)) existing.tags.push(t);
+        }
+        if (!existing.note.trim() && entry.note.trim()) existing.note = entry.note;
+      } else {
+        byTurn.set(entry.turnId, {
+          sessionId,
+          turnId: entry.turnId,
+          note: entry.note,
+          tags: [...entry.tags],
+          reusable,
+          antiPattern,
+        });
+      }
     }
+    flagged.push(...byTurn.values());
   }
   flagged.sort((a, b) =>
     a.sessionId === b.sessionId ? a.turnId - b.turnId : a.sessionId < b.sessionId ? -1 : 1,
@@ -207,13 +222,17 @@ export function computeSessionFeedbackCounts(
   const counts = new Map<string, SessionFeedbackCounts>();
   for (const [sessionId, entries] of feedback) {
     let bookmarked = false;
-    let reusableCount = 0;
-    let antiPatternCount = 0;
+    // Count distinct flagged TURNS, not entries: block-level feedback can carry
+    // several entries for one turn, which must not inflate the human signal.
+    const reusableTurns = new Set<number>();
+    const antiPatternTurns = new Set<number>();
     for (const entry of entries) {
       if (entry.bookmarked) bookmarked = true;
-      if (tagSetHas(entry, REUSABLE_TAG)) reusableCount++;
-      if (tagSetHas(entry, ANTI_PATTERN_TAG)) antiPatternCount++;
+      if (tagSetHas(entry, REUSABLE_TAG)) reusableTurns.add(entry.turnId);
+      if (tagSetHas(entry, ANTI_PATTERN_TAG)) antiPatternTurns.add(entry.turnId);
     }
+    const reusableCount = reusableTurns.size;
+    const antiPatternCount = antiPatternTurns.size;
     if (bookmarked || reusableCount > 0 || antiPatternCount > 0) {
       counts.set(sessionId, { bookmarked, reusableCount, antiPatternCount });
     }

--- a/scripts/knowledge-graph/bm25.ts
+++ b/scripts/knowledge-graph/bm25.ts
@@ -23,7 +23,15 @@ export const BM25_B = 0.75; // document-length normalization strength
  * unchanged.
  */
 export function buildBm25(
-  documents: Map<string, string[]>
+  documents: Map<string, string[]>,
+  /**
+   * Minimum document frequency for a term to enter the vocabulary. The default
+   * (2) suits the cross-session knowledge graph, where df==1 terms are noise.
+   * Turn-level retrieval (one short doc per turn) should pass 1, otherwise a
+   * distinctive query term that appears in a single turn is dropped and the
+   * whole sparse channel collapses to zero.
+   */
+  minDf = 2
 ): Bm25Result {
   // Build vocabulary
   const df = new Map<string, number>(); // document frequency
@@ -38,12 +46,12 @@ export function buildBm25(
   // The absolute cap (n - 1) guarantees a term present in EVERY doc (df == n)
   // is always excluded, even for tiny corpora where floor(n*0.8) would admit it.
   const n = documents.size;
-  const maxDf = Math.min(Math.max(2, Math.floor(n * 0.8)), n - 1);
+  const maxDf = Math.min(Math.max(minDf, Math.floor(n * 0.8)), n - 1);
   const vocabulary: string[] = [];
   const vocabIndex = new Map<string, number>();
 
   for (const [term, count] of df) {
-    if (count >= 2 && count <= maxDf) {
+    if (count >= minDf && count <= maxDf) {
       vocabIndex.set(term, vocabulary.length);
       vocabulary.push(term);
     }

--- a/scripts/knowledge-graph/embedding-io.ts
+++ b/scripts/knowledge-graph/embedding-io.ts
@@ -92,7 +92,7 @@ export function createTransformersBackend(
 
   async function getExtractor() {
     if (extractorPromise) return extractorPromise;
-    extractorPromise = (async () => {
+    const loading = (async () => {
       // Dynamic import so test code that never calls embed() does not load the
       // heavy native dependency.
       const { pipeline } = await import("@huggingface/transformers");
@@ -107,7 +107,13 @@ export function createTransformersBackend(
         return rows.map((r) => Float32Array.from(r));
       };
     })();
-    return extractorPromise;
+    // Don't cache a rejected load: a transient network error should stay
+    // retryable rather than poison every later embed() call.
+    loading.catch(() => {
+      if (extractorPromise === loading) extractorPromise = null;
+    });
+    extractorPromise = loading;
+    return loading;
   }
 
   return {

--- a/scripts/knowledge-graph/embedding-io.ts
+++ b/scripts/knowledge-graph/embedding-io.ts
@@ -56,6 +56,15 @@ export interface LoadedEmbeddingIndex {
 export function readEmbeddingIndex(dir: string): LoadedEmbeddingIndex {
   const metaRaw = fs.readFileSync(path.join(dir, META_FILENAME), "utf8");
   const meta = JSON.parse(metaRaw) as EmbeddingMeta;
+  // Validate the externally-stored shape before arithmetic, so a corrupt/old
+  // meta.json fails with a clear cause instead of a misleading NaN mismatch.
+  if (
+    !Number.isInteger(meta?.dim) || meta.dim <= 0 ||
+    !Number.isInteger(meta?.count) || meta.count < 0 ||
+    !Array.isArray(meta?.chunks)
+  ) {
+    throw new Error(`malformed embedding ${META_FILENAME} in ${dir}`);
+  }
   const buf = fs.readFileSync(path.join(dir, INDEX_FILENAME));
   const matrix = new Int8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   if (matrix.length !== meta.count * meta.dim) {

--- a/scripts/knowledge-graph/retriever.ts
+++ b/scripts/knowledge-graph/retriever.ts
@@ -55,9 +55,10 @@ interface RetrieverInputs {
   backend: EmbeddingBackend;
 }
 
-/** Min-max normalize an array into [0, 1]. A flat array maps to all-zeros. */
+/** Min-max normalize an array into [0, 1]. A flat array maps to all-zeros.
+ *  Always returns a fresh array (never the input reference). */
 function minMaxNormalize(values: number[]): number[] {
-  if (values.length === 0) return values;
+  if (values.length === 0) return [];
   let min = Infinity;
   let max = -Infinity;
   for (const v of values) {

--- a/scripts/knowledge-graph/retriever.ts
+++ b/scripts/knowledge-graph/retriever.ts
@@ -172,6 +172,18 @@ export function createRetrieverFromIndex(params: {
   backend: EmbeddingBackend;
 }): Retriever {
   const { chunks, matrix, dim, chunkTexts, backend } = params;
+  // chunkTexts (re-derived for BM25) must align 1:1 with the indexed chunks;
+  // a silent misalignment would score chunk i with another chunk's text.
+  if (chunkTexts.length !== chunks.length) {
+    throw new Error(
+      `retriever chunkTexts length (${chunkTexts.length}) != chunks length (${chunks.length})`
+    );
+  }
+  if (matrix.length !== chunks.length * dim) {
+    throw new Error(
+      `retriever matrix length (${matrix.length}) != chunks * dim (${chunks.length} * ${dim})`
+    );
+  }
   const denseVectors: Float32Array[] = chunks.map((_, i) =>
     dequantize(matrix.subarray(i * dim, (i + 1) * dim))
   );

--- a/scripts/knowledge-graph/retriever.ts
+++ b/scripts/knowledge-graph/retriever.ts
@@ -93,9 +93,11 @@ export function createRetriever(inputs: RetrieverInputs): Retriever {
   const { chunks, texts, denseVectors, backend } = inputs;
 
   // Precompute BM25 over chunk texts once. Document ids are chunk indices.
+  // minDf=1: each chunk is one short turn, so a distinctive term in a single
+  // turn must stay in the vocabulary or the sparse channel goes inert.
   const docs = new Map<string, string[]>();
   texts.forEach((t, i) => docs.set(String(i), tokenize(t)));
-  const bm25 = buildBm25(docs);
+  const bm25 = buildBm25(docs, 1);
 
   async function retrieve(
     query: string,

--- a/scripts/knowledge-graph/reusability.ts
+++ b/scripts/knowledge-graph/reusability.ts
@@ -3,7 +3,7 @@
  * Quantifies how valuable a topic pattern is for automation as skill/hook.
  */
 
-import type { TopicNode, ReusabilityScore, FacetsData } from "./types.js";
+import type { TopicNode, ReusabilityScore, FacetsData, SessionFeedbackCounts } from "./types.js";
 import { helpfulnessToScore } from "./facets-reader.js";
 
 /** Weight profile used when no facets data is available. */
@@ -31,12 +31,11 @@ export const FACETS_WEIGHTS = {
  */
 export const HUMAN_SIGNAL_WEIGHT = 0.1;
 
-/** Per-session feedback counts used to derive a human signal. */
-export interface SessionHumanSignal {
-  bookmarked: boolean;
-  reusableCount: number;
-  antiPatternCount: number;
-}
+/**
+ * Per-session feedback counts used to derive a human signal. Alias of the
+ * canonical {@link SessionFeedbackCounts} (kept for the public barrel export).
+ */
+export type SessionHumanSignal = SessionFeedbackCounts;
 
 /**
  * Map one session's feedback counts to a signal in [0,1]. Neutral baseline is
@@ -46,7 +45,7 @@ export interface SessionHumanSignal {
  * Pure and deterministic so the synthesis pipeline (and tests) can reason about
  * the signal independently of the topic-level aggregation.
  */
-export function computeSessionHumanSignal(s: SessionHumanSignal): number {
+export function computeSessionHumanSignal(s: SessionFeedbackCounts): number {
   let signal = 0.5;
   if (s.bookmarked) signal += 0.15;
   signal += 0.2 * Math.min(s.reusableCount, 3);

--- a/scripts/knowledge-graph/types.ts
+++ b/scripts/knowledge-graph/types.ts
@@ -66,6 +66,16 @@ export interface ReusabilityScore {
   weightProfile?: "base" | "facets";
 }
 
+/**
+ * Per-session human-feedback counts (issue #24). Canonical home so the feedback
+ * reader and the reusability scorer share one shape instead of structural twins.
+ */
+export interface SessionFeedbackCounts {
+  bookmarked: boolean;
+  reusableCount: number;
+  antiPatternCount: number;
+}
+
 export interface TopicNode {
   id: string;
   label: string;

--- a/scripts/skill-server.ts
+++ b/scripts/skill-server.ts
@@ -1,9 +1,9 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble } from "./skill-synthesizer.js";
 import type { SynthesisRequest, SynthesisResponse } from "./skill-synthesizer.js";
-import { mergeFeedbackBlob, normalizeFeedbackBlob, type FeedbackBlob } from "./feedback-reader.js";
+import { mergeFeedbackBlob, readFeedbackBlob, type FeedbackBlob } from "./feedback-reader.js";
 
 // ---------- Constants ----------
 
@@ -78,17 +78,6 @@ async function handleSynthesize(req: IncomingMessage, res: ServerResponse) {
   sendJson(res, 200, { success: true, synthesizedMarkdown: stripSynthesisPreamble(result.stdout) } satisfies SynthesisResponse);
 }
 
-/** Read the on-disk feedback map (normalized), or {} if absent/corrupt. */
-function readFeedbackFile(filePath = FEEDBACK_FILE): FeedbackBlob {
-  if (!existsSync(filePath)) return {};
-  try {
-    const raw = readFileSync(filePath, "utf-8");
-    return normalizeFeedbackBlob(JSON.parse(raw));
-  } catch {
-    return {};
-  }
-}
-
 /** Atomically replace `filePath` with `blob` (write temp, then rename) so a
  *  crash mid-write cannot leave a truncated, unparseable feedback.json. */
 function writeFeedbackFile(blob: FeedbackBlob, filePath = FEEDBACK_FILE): void {
@@ -111,7 +100,7 @@ export function mergeFeedbackPost(
   filePath = FEEDBACK_FILE,
 ): Promise<void> {
   const task = feedbackChain.then(() => {
-    const merged = mergeFeedbackBlob(readFeedbackFile(filePath), sessionId, entries);
+    const merged = mergeFeedbackBlob(readFeedbackBlob(filePath), sessionId, entries);
     writeFeedbackFile(merged, filePath);
   });
   feedbackChain = task.catch(() => {});
@@ -119,7 +108,7 @@ export function mergeFeedbackPost(
 }
 
 function handleGetFeedback(res: ServerResponse) {
-  sendJson(res, 200, readFeedbackFile());
+  sendJson(res, 200, readFeedbackBlob(FEEDBACK_FILE));
 }
 
 /**

--- a/scripts/skill-server.ts
+++ b/scripts/skill-server.ts
@@ -23,10 +23,23 @@ const CORS_HEADERS: Record<string, string> = {
 
 // ---------- Helpers ----------
 
-function readBody(req: IncomingMessage): Promise<string> {
+/** Max request body size. Bounds memory for a local server that allows any
+ *  origin; synthesis graph-context payloads are well under this. */
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+function readBody(req: IncomingMessage, maxBytes = MAX_BODY_BYTES): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
     req.on("error", reject);
   });

--- a/scripts/skill-server.ts
+++ b/scripts/skill-server.ts
@@ -1,5 +1,5 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble } from "./skill-synthesizer.js";
 import type { SynthesisRequest, SynthesisResponse } from "./skill-synthesizer.js";
@@ -66,19 +66,43 @@ async function handleSynthesize(req: IncomingMessage, res: ServerResponse) {
 }
 
 /** Read the on-disk feedback map (normalized), or {} if absent/corrupt. */
-function readFeedbackFile(): FeedbackBlob {
-  if (!existsSync(FEEDBACK_FILE)) return {};
+function readFeedbackFile(filePath = FEEDBACK_FILE): FeedbackBlob {
+  if (!existsSync(filePath)) return {};
   try {
-    const raw = readFileSync(FEEDBACK_FILE, "utf-8");
+    const raw = readFileSync(filePath, "utf-8");
     return normalizeFeedbackBlob(JSON.parse(raw));
   } catch {
     return {};
   }
 }
 
-function writeFeedbackFile(blob: FeedbackBlob): void {
-  mkdirSync(dirname(FEEDBACK_FILE), { recursive: true });
-  writeFileSync(FEEDBACK_FILE, JSON.stringify(blob, null, 2), "utf-8");
+/** Atomically replace `filePath` with `blob` (write temp, then rename) so a
+ *  crash mid-write cannot leave a truncated, unparseable feedback.json. */
+function writeFeedbackFile(blob: FeedbackBlob, filePath = FEEDBACK_FILE): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(blob, null, 2), "utf-8");
+  renameSync(tmp, filePath);
+}
+
+/**
+ * Serialize the feedback read-modify-write. The browser fires fire-and-forget
+ * sync POSTs, so two requests for different sessions can otherwise both read the
+ * same snapshot and the second writer silently reverts the first's bucket. The
+ * chain guarantees each merge sees the previous one's result. Exported for tests.
+ */
+let feedbackChain: Promise<unknown> = Promise.resolve();
+export function mergeFeedbackPost(
+  sessionId: string,
+  entries: unknown[],
+  filePath = FEEDBACK_FILE,
+): Promise<void> {
+  const task = feedbackChain.then(() => {
+    const merged = mergeFeedbackBlob(readFeedbackFile(filePath), sessionId, entries);
+    writeFeedbackFile(merged, filePath);
+  });
+  feedbackChain = task.catch(() => {});
+  return task;
 }
 
 function handleGetFeedback(res: ServerResponse) {
@@ -105,9 +129,7 @@ async function handlePostFeedback(req: IncomingMessage, res: ServerResponse) {
   }
 
   try {
-    const current = readFeedbackFile();
-    const merged = mergeFeedbackBlob(current, body.sessionId, body.entries);
-    writeFeedbackFile(merged);
+    await mergeFeedbackPost(body.sessionId, body.entries);
     sendJson(res, 200, { ok: true });
   } catch (err) {
     sendJson(res, 500, { error: err instanceof Error ? err.message : "Failed to persist feedback" });


### PR DESCRIPTION
Retroactive review of the already-merged Wave A PRs (#66 cli-type-fix, #67 #24 human-feedback, #68 #32/#35 RAG) via `/nirami` (forest/stone/river) + `/code-review` (high). One commit per finding.

## Correctness / data integrity
- **fix(feedback): collapse block-level entries to one signal per turn** — `FeedbackEntry` can be block-level (`blockId`), so a turn flagged on several tool-call blocks produced duplicate `FlaggedTurn`s and inflated reusable/anti-pattern counts, over-weighting one human turn in the synthesis prompt **and** the reusability score. `selectFlaggedTurns` now merges by `turnId`; counts use distinct-turn Sets. *(code-review #1/#2)*
- **fix(skill-server): atomic + serialized feedback writes** — direct `writeFileSync` could leave truncated JSON on a crash (then swallowed as `{}` = silent total loss); concurrent cross-session POSTs raced read-modify-write and reverted each other. Temp-file + `rename`, and a serialized merge chain. *(river #1 + code-review)*
- **fix(retriever): keep BM25 sparse channel alive on turn-level chunks** — `buildBm25` dropped df<2 terms, so a distinctive term in a single turn vanished and hybrid silently degenerated to dense-only. Added `minDf` (default 2; retriever passes 1). *(code-review #4)*
- **fix(retriever): assert chunkTexts/matrix align with chunks** — `createRetrieverFromIndex` zipped re-derived BM25 texts against the index by position with no length check (latent silent-misranking trap). Fail fast. *(code-review)*
- **fix(embed): validate meta.json shape** — `count`/`dim` were trusted, so a corrupt meta gave a misleading `NaN` size-mismatch. *(forest #6 / river #4)*
- **fix(embed): allow retry after a failed model load** — `getExtractor` cached the rejected promise, permanently poisoning the backend after one transient network failure. *(river #5)*
- **fix(skill-server): cap request body size** — unbounded `readBody` under permissive CORS. *(river #2)*
- **fix(feedback): tagSetHas case-insensitive on both operands** *(forest #2)*

## Cleanup / DRY / perf
- **refactor(feedback): share readFeedbackBlob** between reader and server (was duplicated tolerant-read logic). *(forest #4)*
- **refactor(types): unify SessionFeedbackCounts / SessionHumanSignal** structural twins (canonical in `knowledge-graph/types.ts`). *(forest #5 / stone #3)*
- **refactor(pipeline): use toSessionInputs in generateOverview** — removed the byte-identical inline mapping the helper was meant to replace (a cherry-pick artifact). *(code-review)*
- **perf(synthesis): read facets once outside the candidate loop** — was re-reading/parsing the facets dir per candidate. *(stone #1)*
- **fix(retriever): minMaxNormalize always returns a fresh array** *(forest #8)*

## Tests
- **test(skill-server): cover feedback persistence handlers** — the server layer was untested; covers persist / drop-empty / clear-bucket / concurrent-serialization. *(river #3)*
- Plus tests added inline with the feedback dedup, meta validation, and BM25 minDf fixes.

## Deliberately deferred (low value / churn / behavior-adjacent)
- `ChunkMeta.role` dead single-value field — harmless; removal churns the meta.json format + several files.
- `nextRule` counter style in `buildSynthesisPrompt` — correct today; cosmetic.
- `feedbackSync` debounce / write-amplification — the cross-session race is now mitigated by the serialized atomic write; debounce is a nice-to-have.
- `weightProfile` union not tracking `+human` — cosmetic type accuracy.
- `FeedbackEntry` frontend/pipeline mirror — intentional (keeps `scripts/` off the frontend tsconfig).

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `eslint` ✅ (0 errors; 2 pre-existing PlaybackSidePanel warnings) · `vitest` ✅ 638/638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)