### PR TITLE
feat(#33): retrieval-enriched skill synthesis prompts (Wave 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,16 @@ Flags on `analyze-sessions` (default **OFF**, promotion gated on the PoC):
 
 PoC harness: `npx tsx scripts/rag-poc.ts` (measures footprint / throughput / latency + A/B; `--fake` forces the no-network backend).
 
+### Retrieval-enriched synthesis (issue #33, opt-in)
+
+`--retrieval-context` (on both `analyze-sessions` and the `crune` CLI, default **OFF** for clean A/B) swaps the loosely-related cluster-blob "examples" slot (Representative User Prompts + Enriched Tool Patterns) for a **Retrieved Relevant Moments** section built from the hybrid retriever's top-k turn snippets (k=8). The rest of the synthesis prompt (frontmatter ask, topic info, graph position, human-flagged moments, heuristic reference) is unchanged.
+
+- **Query** per candidate: `buildRetrievalQuery(candidate, topic)` = topic label + top keywords + truncated heuristic `skillMarkdown` (600 chars). Pure/testable.
+- **Section**: `buildRetrievedMomentsSection(chunks)` renders `[sessionId#turnIndex] (score: N.NNN) snippet`; `SynthesisRequest.retrievedContext?: RetrievedChunk[]` threads it into `buildSynthesisPrompt`. When present and non-empty, the blob slots are suppressed and a numbered task rule grounds the skill in the retrieved moments.
+- **Retriever wiring** (`buildSynthesisRetriever` in `analyze-sessions.ts`): reuse the EmbedResult from `--embed` if it ran this run → else read an on-disk index at `public/data/embeddings/` → else embed fresh in-memory via `createTransformersBackend` + `embedSessions`. BM25 text is re-derived with `extractChunks` (same chunk order as the index). On any failure (no index, no backend) it logs a warning and returns `null` so synthesis FALLS BACK to the cluster blob (never crashes).
+- **Preview A/B** (`crune --preview --retrieval-context`): the synthesis loop prints `Context strategy: retrieval (N moments)` vs `cluster blob` per candidate so a human can compare side by side.
+- **Measurement**: the #20 evaluator path (`overallScore`) is unchanged — run `--retrieval-context` vs without and compare `SkillCandidate.evaluation.overallScore` to A/B synthesis quality. Tests inject a fake `EmbeddingBackend`/in-memory retriever; the `claude -p` call stays behind the `synthesizeWithClaude` seam (never invoked in tests).
+
 ## Session Summarization
 
 セッション一覧の `firstUserPrompt` フィールドは、facetsデータが利用可能な場合は `/insights` の `brief_summary`（LLM生成の要約）で置き換えられる。facetsがないセッションは従来通り最初のユーザープロンプトを表示する。

--- a/scripts/__tests__/analyze-sessions-args.test.ts
+++ b/scripts/__tests__/analyze-sessions-args.test.ts
@@ -56,4 +56,18 @@ describe("parseArgs (analyze-sessions)", () => {
     expect(args.embed).toBe(true);
     expect(args.embedModel).toBe("Xenova/custom");
   });
+
+  it("defaults retrievalContext OFF (clean A/B, issue #33)", () => {
+    expect(parseArgs([]).retrievalContext).toBe(false);
+  });
+
+  it("enables retrieval context with --retrieval-context", () => {
+    expect(parseArgs(["--retrieval-context"]).retrievalContext).toBe(true);
+  });
+
+  it("keeps retrieval context independent from embed", () => {
+    const args = parseArgs(["--retrieval-context"]);
+    expect(args.retrievalContext).toBe(true);
+    expect(args.embed).toBe(false);
+  });
 });

--- a/scripts/__tests__/cli.test.ts
+++ b/scripts/__tests__/cli.test.ts
@@ -67,6 +67,12 @@ describe("parseCliArgs", () => {
     expect(result.evalModel).toBeUndefined();
     expect(result.preview).toBe(false);
     expect(result.json).toBe(false);
+    expect(result.retrievalContext).toBe(false);
+  });
+
+  it("sets retrievalContext with --retrieval-context (issue #33)", () => {
+    const result = parseCliArgs(["node", "cli.ts", "--retrieval-context"]);
+    expect(result.retrievalContext).toBe(true);
   });
 
   it("sets preview with --preview", () => {

--- a/scripts/__tests__/retrieval-synthesis.test.ts
+++ b/scripts/__tests__/retrieval-synthesis.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSynthesisPrompt,
+  buildRetrievalQuery,
+  buildRetrievedMomentsSection,
+  type SynthesisRequest,
+  type RetrievedChunk,
+} from "../skill-synthesizer.js";
+import { createRetriever } from "../knowledge-graph/retriever.js";
+import type { EmbeddingBackend, ChunkMeta } from "../knowledge-graph/embedder.js";
+
+function baseRequest(): SynthesisRequest {
+  return {
+    skillCandidate: {
+      topicId: "t1",
+      reusabilityScore: 0.5,
+      skillMarkdown: "# heuristic skill\nDo the thing with Edit and Bash.",
+    },
+    topicNode: {
+      id: "t1",
+      label: "Bugfix Workflow",
+      keywords: ["fix", "bug", "regression"],
+      dominantRole: "user-driven",
+      projects: ["p"],
+      project: "p",
+      sessionCount: 2,
+      totalDurationMinutes: 30,
+      totalToolCalls: 10,
+      toolSignature: [{ tool: "Edit", weight: 0.5 }],
+      representativePrompts: ["fix the login bug", "resolve the regression"],
+      suggestedPrompt: "fix",
+      reusabilityScore: {
+        overall: 0.5,
+        frequency: 0.5,
+        timeCost: 0.5,
+        crossProjectScore: 0,
+        recency: 0.5,
+      },
+      betweennessCentrality: 0,
+      degreeCentrality: 0,
+    },
+    enrichedSequences: [
+      {
+        sequence: [
+          { toolName: "Read", category: "read" },
+          { toolName: "Edit", category: "write" },
+        ],
+        count: 3,
+        sessionIds: ["s1"],
+        projects: ["p"],
+      },
+    ],
+  };
+}
+
+const retrieved: RetrievedChunk[] = [
+  { sessionId: "sess-A", turnIndex: 4, snippet: "User: reproduce the auth crash", score: 0.912 },
+  { sessionId: "sess-B", turnIndex: 1, snippet: "User: add a failing test first", score: 0.734 },
+];
+
+describe("buildRetrievalQuery", () => {
+  it("combines label, keywords, and truncated heuristic markdown", () => {
+    const r = baseRequest();
+    const query = buildRetrievalQuery(r.skillCandidate, r.topicNode);
+    expect(query).toContain("Bugfix Workflow");
+    expect(query).toContain("fix bug regression");
+    expect(query).toContain("heuristic skill");
+  });
+
+  it("collapses whitespace and truncates very long markdown", () => {
+    const longMd = "word ".repeat(500); // 2500 chars
+    const query = buildRetrievalQuery(
+      { skillMarkdown: longMd },
+      { label: "L", keywords: ["k"] }
+    );
+    // 600-char markdown cap + "L k " prefix; comfortably under the raw length.
+    expect(query.length).toBeLessThan(700);
+    expect(query.startsWith("L k word")).toBe(true);
+  });
+
+  it("omits empty pieces without leaving stray separators", () => {
+    const query = buildRetrievalQuery(
+      { skillMarkdown: "" },
+      { label: "Only Label", keywords: [] }
+    );
+    expect(query).toBe("Only Label");
+  });
+});
+
+describe("buildRetrievedMomentsSection", () => {
+  it("returns empty string with no chunks", () => {
+    expect(buildRetrievedMomentsSection([])).toBe("");
+  });
+
+  it("renders sessionId#turnIndex, score, and snippet per chunk", () => {
+    const section = buildRetrievedMomentsSection(retrieved);
+    expect(section).toContain("Retrieved Relevant Moments");
+    expect(section).toContain("[sess-A#4]");
+    expect(section).toContain("(score: 0.912)");
+    expect(section).toContain("reproduce the auth crash");
+    expect(section).toContain("[sess-B#1]");
+  });
+});
+
+describe("buildSynthesisPrompt retrieval gating (issue #33)", () => {
+  it("omits the Retrieved Relevant Moments section when retrievedContext is absent", () => {
+    const prompt = buildSynthesisPrompt(baseRequest());
+    expect(prompt).not.toContain("Retrieved Relevant Moments");
+    // Cluster blob is present in the fallback (A/B baseline).
+    expect(prompt).toContain("Representative User Prompts");
+    expect(prompt).toContain("Enriched Tool Patterns");
+  });
+
+  it("omits the section when retrievedContext is an empty array (fallback to blob)", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), retrievedContext: [] });
+    expect(prompt).not.toContain("Retrieved Relevant Moments");
+    expect(prompt).toContain("Representative User Prompts");
+  });
+
+  it("includes the section only when retrievedContext is present", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), retrievedContext: retrieved });
+    expect(prompt).toContain("Retrieved Relevant Moments");
+    expect(prompt).toContain("[sess-A#4]");
+  });
+
+  it("REPLACES the cluster-blob examples when retrieval context is present", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), retrievedContext: retrieved });
+    // The loosely-related blob slots are suppressed in favour of retrieval.
+    expect(prompt).not.toContain("Representative User Prompts");
+    expect(prompt).not.toContain("Enriched Tool Patterns");
+  });
+
+  it("appends a task rule grounding the skill in retrieved moments", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), retrievedContext: retrieved });
+    expect(prompt).toMatch(/Ground "When to Use".*Retrieved Relevant Moments/);
+  });
+
+  it("keeps the rest of the prompt structure intact (topic, tool signature, reference)", () => {
+    const prompt = buildSynthesisPrompt({ ...baseRequest(), retrievedContext: retrieved });
+    expect(prompt).toContain("Topic Information");
+    expect(prompt).toContain("Tool Signature");
+    expect(prompt).toContain("Current Heuristic-Generated Skill");
+  });
+});
+
+// ─── End-to-end: query → fake retriever → prompt (no network) ────────────────
+
+/** Deterministic backend mapping known concepts to fixed unit vectors. */
+function conceptBackend(): EmbeddingBackend {
+  const dim = 3;
+  const concepts: Record<string, Float32Array> = {
+    bug: Float32Array.from([1, 0, 0]),
+    auth: Float32Array.from([0, 1, 0]),
+    css: Float32Array.from([0, 0, 1]),
+  };
+  return {
+    dim,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      return texts.map((text) => {
+        const out = new Float32Array(dim);
+        const t = text.toLowerCase();
+        for (const [key, v] of Object.entries(concepts)) {
+          if (t.includes(key)) for (let i = 0; i < dim; i++) out[i] += v[i];
+        }
+        let n = 0;
+        for (const x of out) n += x * x;
+        n = Math.sqrt(n);
+        if (n > 0) for (let i = 0; i < dim; i++) out[i] /= n;
+        return out;
+      });
+    },
+  };
+}
+
+describe("retrieval → synthesis integration (fake backend, no network)", () => {
+  async function buildIndexedRetriever(texts: { sessionId: string; text: string }[]) {
+    const backend = conceptBackend();
+    const chunks: ChunkMeta[] = texts.map((t, i) => ({
+      sessionId: t.sessionId,
+      turnIndex: i,
+      role: "user-turn" as const,
+      snippet: t.text,
+    }));
+    const denseVectors = await backend.embed(texts.map((t) => t.text));
+    return createRetriever({ chunks, texts: texts.map((t) => t.text), denseVectors, backend });
+  }
+
+  it("feeds the candidate query into the retriever and injects the top hits", async () => {
+    const retriever = await buildIndexedRetriever([
+      { sessionId: "s1", text: "set up css styling for the page" },
+      { sessionId: "s2", text: "fix the login bug regression" },
+      { sessionId: "s3", text: "wire up auth tokens" },
+    ]);
+
+    const req = baseRequest();
+    const query = buildRetrievalQuery(req.skillCandidate, req.topicNode);
+    const hits = await retriever.retrieve(query, 8);
+    expect(hits.length).toBeGreaterThan(0);
+    // The "bug" concept in label/keywords/markdown should surface s2 first.
+    expect(hits[0].sessionId).toBe("s2");
+
+    const prompt = buildSynthesisPrompt({ ...req, retrievedContext: hits });
+    expect(prompt).toContain("Retrieved Relevant Moments");
+    expect(prompt).toContain("[s2#1]");
+    expect(prompt).not.toContain("Representative User Prompts");
+  });
+
+  it("falls back to the cluster blob when the retriever is empty (no index)", async () => {
+    const empty = await buildIndexedRetriever([]);
+    const req = baseRequest();
+    const query = buildRetrievalQuery(req.skillCandidate, req.topicNode);
+    const hits = await empty.retrieve(query, 8);
+    expect(hits).toEqual([]);
+
+    // Caller passes undefined (no usable context) → cluster blob retained.
+    const prompt = buildSynthesisPrompt({ ...req, retrievedContext: hits.length > 0 ? hits : undefined });
+    expect(prompt).not.toContain("Retrieved Relevant Moments");
+    expect(prompt).toContain("Representative User Prompts");
+  });
+});

--- a/scripts/__tests__/retrieval-synthesis.test.ts
+++ b/scripts/__tests__/retrieval-synthesis.test.ts
@@ -6,7 +6,8 @@ import {
   type SynthesisRequest,
   type RetrievedChunk,
 } from "../skill-synthesizer.js";
-import { createRetriever } from "../knowledge-graph/retriever.js";
+import { createRetriever, type Retriever } from "../knowledge-graph/retriever.js";
+import { retrieveContextForCandidate } from "../knowledge-graph/synthesis-retriever.js";
 import type { EmbeddingBackend, ChunkMeta } from "../knowledge-graph/embedder.js";
 
 function baseRequest(): SynthesisRequest {
@@ -196,8 +197,13 @@ describe("retrieval → synthesis integration (fake backend, no network)", () =>
     const query = buildRetrievalQuery(req.skillCandidate, req.topicNode);
     const hits = await retriever.retrieve(query, 8);
     expect(hits.length).toBeGreaterThan(0);
-    // The "bug" concept in label/keywords/markdown should surface s2 first.
-    expect(hits[0].sessionId).toBe("s2");
+    // Relative assertion (tests wiring, not the exact dense/BM25 blend): the
+    // "bug" concept in label/keywords/markdown should surface s2 and rank it
+    // above the irrelevant css session s1.
+    const ranked = hits.map((h) => h.sessionId);
+    expect(ranked).toContain("s2");
+    const s1Pos = ranked.indexOf("s1");
+    expect(ranked.indexOf("s2")).toBeLessThan(s1Pos === -1 ? Infinity : s1Pos);
 
     const prompt = buildSynthesisPrompt({ ...req, retrievedContext: hits });
     expect(prompt).toContain("Retrieved Relevant Moments");
@@ -216,5 +222,54 @@ describe("retrieval → synthesis integration (fake backend, no network)", () =>
     const prompt = buildSynthesisPrompt({ ...req, retrievedContext: hits.length > 0 ? hits : undefined });
     expect(prompt).not.toContain("Retrieved Relevant Moments");
     expect(prompt).toContain("Representative User Prompts");
+  });
+});
+
+// ─── retrieveContextForCandidate fallback (no network) ───────────────────────
+
+describe("retrieveContextForCandidate fallback (issue #33)", () => {
+  const req = baseRequest();
+  const topic = { label: req.topicNode.label, keywords: req.topicNode.keywords };
+
+  it("returns undefined and the prompt falls back to the blob when retrieve throws", async () => {
+    // Fake retriever whose retrieve rejects — mimics a backend/model failure.
+    const throwing: Retriever = {
+      size: 3,
+      async retrieve(): Promise<never> {
+        throw new Error("backend unavailable");
+      },
+    };
+
+    const ctx = await retrieveContextForCandidate(throwing, req.skillCandidate, topic);
+    expect(ctx).toBeUndefined();
+
+    // The orchestration passes the undefined context straight through, so the
+    // cluster-blob examples are retained (never crashes synthesis).
+    const prompt = buildSynthesisPrompt({ ...req, retrievedContext: ctx });
+    expect(prompt).not.toContain("Retrieved Relevant Moments");
+    expect(prompt).toContain("Representative User Prompts");
+    expect(prompt).toContain("Enriched Tool Patterns");
+  });
+
+  it("returns undefined when retrieve yields no hits (empty index)", async () => {
+    const empty: Retriever = {
+      size: 0,
+      async retrieve() {
+        return [];
+      },
+    };
+    const ctx = await retrieveContextForCandidate(empty, req.skillCandidate, topic);
+    expect(ctx).toBeUndefined();
+  });
+
+  it("returns the hits when retrieve succeeds", async () => {
+    const ok: Retriever = {
+      size: 1,
+      async retrieve() {
+        return retrieved;
+      },
+    };
+    const ctx = await retrieveContextForCandidate(ok, req.skillCandidate, topic);
+    expect(ctx).toEqual(retrieved);
   });
 });

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -19,11 +19,18 @@ import {
   type SemanticKnowledgeGraph,
   embedSessions,
   writeEmbeddingIndex,
+  readEmbeddingIndex,
   createTransformersBackend,
+  createRetriever,
+  createRetrieverFromIndex,
+  extractChunks,
+  dequantize,
   DEFAULT_EMBED_MODEL,
   DEFAULT_EMBED_DIM,
+  type Retriever,
+  type EmbedResult,
 } from "./knowledge-graph-builder.js";
-import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions, type HumanFeedbackSignal } from "./skill-synthesizer.js";
+import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, buildRetrievalQuery, type SynthesisOptions, type HumanFeedbackSignal, type RetrievedChunk } from "./skill-synthesizer.js";
 import { computeSessionHumanSignal } from "./knowledge-graph/reusability.js";
 import {
   readFeedbackFile,
@@ -63,6 +70,7 @@ export interface CliArgs {
   feedbackFile: string;
   embed: boolean;
   embedModel?: string;
+  retrievalContext: boolean;
 }
 
 /**
@@ -85,6 +93,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   let feedbackFile = path.resolve("public", "data", "feedback.json");
   let embed = false;
   let embedModel: string | undefined;
+  let retrievalContext = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--sessions-dir" && args[i + 1]) {
@@ -122,6 +131,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       embed = true;
     } else if (args[i] === "--embed-model" && args[i + 1]) {
       embedModel = args[++i];
+    } else if (args[i] === "--retrieval-context") {
+      retrievalContext = true;
     }
   }
   return {
@@ -139,6 +150,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     feedbackFile,
     embed,
     embedModel,
+    retrievalContext,
   };
 }
 
@@ -318,7 +330,16 @@ interface SynthesisConfig {
   evalThreshold?: number;
   useHumanFeedback?: boolean;
   feedbackFile?: string;
+  /**
+   * Hybrid retriever for retrieval-enriched synthesis (issue #33). When present,
+   * each candidate's cluster-blob examples are replaced by the top-k retrieved
+   * relevant moments. Absent => existing cluster-blob behaviour (default A/B).
+   */
+  retriever?: Retriever;
 }
+
+/** Top-k turn snippets retrieved per candidate for synthesis context (#33). */
+const RETRIEVAL_TOP_K = 8;
 
 /**
  * Map parsed sessions onto the `SessionInput` shape consumed by the knowledge
@@ -365,6 +386,88 @@ function toSessionInputs(sessions: ParsedSession[]): SessionInput[] {
       subagentCount: s.meta.subagentCount,
     },
   }));
+}
+
+/**
+ * Build a hybrid retriever for retrieval-enriched synthesis (issue #33).
+ *
+ * Strategy, in order of preference:
+ *   1. Reuse an embedding index already computed this run (`precomputed`, from
+ *      the `--embed` step) — zero extra model calls.
+ *   2. Read an on-disk index at `embeddingsDir` (from a prior `--embed` run).
+ *   3. Embed the analyzed sessions fresh via the production backend.
+ *
+ * BM25 needs the full chunk text, which the persisted meta.json does NOT store
+ * (only the short snippet). We re-derive it with `extractChunks` (same order as
+ * the index) and zip by index. Returns `null` (never throws) when no index and
+ * no usable backend are available, so the caller falls back to the cluster blob.
+ */
+async function buildSynthesisRetriever(
+  sessionInputs: SessionInput[],
+  embeddingsDir: string,
+  model: string,
+  precomputed?: EmbedResult
+): Promise<{ retriever: Retriever; strategy: string } | null> {
+  // extractChunks is the canonical chunk order shared with the embedder; its
+  // `text` field is what BM25 indexes.
+  const extracted = extractChunks(sessionInputs);
+  if (extracted.length === 0) {
+    console.error("[crune] Retrieval context: no chunks to index, falling back to cluster blob");
+    return null;
+  }
+  const chunkTexts = extracted.map((c) => c.text);
+
+  try {
+    const backend = createTransformersBackend(model, DEFAULT_EMBED_DIM);
+
+    // (1) Reuse embeddings computed earlier this run.
+    if (precomputed && precomputed.count === extracted.length) {
+      const retriever = createRetrieverFromIndex({
+        chunks: precomputed.chunks,
+        matrix: precomputed.matrix,
+        dim: precomputed.dim,
+        chunkTexts,
+        backend,
+      });
+      return { retriever, strategy: "reused --embed index (this run)" };
+    }
+
+    // (2) Reuse an index persisted by a prior run.
+    if (fs.existsSync(path.join(embeddingsDir, "meta.json"))) {
+      const { meta, matrix } = readEmbeddingIndex(embeddingsDir);
+      if (meta.count === extracted.length) {
+        const retriever = createRetrieverFromIndex({
+          chunks: meta.chunks,
+          matrix,
+          dim: meta.dim,
+          chunkTexts,
+          backend,
+        });
+        return { retriever, strategy: `on-disk index (${embeddingsDir})` };
+      }
+      console.error(
+        `[crune] Retrieval context: on-disk index count ${meta.count} != ${extracted.length} chunks, re-embedding`
+      );
+    }
+
+    // (3) Embed fresh in-memory.
+    const result = await embedSessions(sessionInputs, backend, { model });
+    const denseVectors = result.chunks.map((_, i) =>
+      dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
+    );
+    const retriever = createRetriever({
+      chunks: result.chunks,
+      texts: chunkTexts,
+      denseVectors,
+      backend,
+    });
+    return { retriever, strategy: "freshly embedded (in-memory)" };
+  } catch (err) {
+    console.error(
+      `[crune] Retrieval context unavailable (falling back to cluster blob): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
 }
 
 async function generateOverview(sessions: ParsedSession[], synthesisConfig: SynthesisConfig = { skip: false, count: 5 }): Promise<OverviewJson> {
@@ -641,12 +744,35 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
         }
       }
 
+      // Retrieval-enriched context (issue #33). When a retriever is available,
+      // pull the top-k most relevant turn snippets for this candidate; on any
+      // failure we leave `retrievedContext` undefined so buildSynthesisPrompt
+      // falls back to the cluster-blob examples (never crash).
+      let retrievedContext: RetrievedChunk[] | undefined;
+      if (synthesisConfig.retriever) {
+        try {
+          const query = buildRetrievalQuery(candidate, topic as unknown as import("./skill-synthesizer.js").TopicNode);
+          const chunks = await synthesisConfig.retriever.retrieve(query, RETRIEVAL_TOP_K);
+          if (chunks.length > 0) {
+            retrievedContext = chunks;
+            console.error(`[crune]   [${i + 1}/${total}] Retrieved ${chunks.length} relevant moments`);
+          } else {
+            console.error(`[crune]   [${i + 1}/${total}] No relevant moments retrieved, using cluster blob`);
+          }
+        } catch (err) {
+          console.error(
+            `[crune]   [${i + 1}/${total}] Retrieval failed (using cluster blob): ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+
       const prompt = buildSynthesisPrompt({
         skillCandidate: candidate,
         topicNode: topic as unknown as import("./skill-synthesizer.js").TopicNode,
         enrichedSequences: relatedSequences,
         facetsInsights: facetsInsights as unknown as import("./skill-synthesizer.js").FacetsInsightsSummary | undefined,
         humanFeedback,
+        retrievedContext,
       });
       const result = await synthesizeWithClaude(prompt, synthOpts);
       if (result.success) {
@@ -749,7 +875,7 @@ function getWeekLabel(date: Date): string {
 // ─── Main Pipeline ──────────────────────────────────────────────────────────
 
 async function main() {
-  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel, evalThreshold, useHumanFeedback, feedbackFile, embed, embedModel } = parseArgs();
+  const { sessionsDir, outputDir, skipSynthesis, synthesisModel, synthesisCount, facetsDir, skipFacets, skipEval, evalModel, evalThreshold, useHumanFeedback, feedbackFile, embed, embedModel, retrievalContext } = parseArgs();
 
   console.error(`[crune] Sessions dir: ${sessionsDir}`);
   console.error(`[crune] Output dir:   ${outputDir}`);
@@ -865,6 +991,49 @@ async function main() {
     `[crune] Wrote ${parsedSessions.length} detail files (${(totalDetailSize / 1024).toFixed(1)} KB total)`
   );
 
+  // Optional: chunk-level embedding index for RAG retrieval (issue #32).
+  // Opt-in (default OFF). Promotion to default is gated on the PoC (#35).
+  // Runs BEFORE overview generation so retrieval-enriched synthesis (#33) can
+  // reuse the freshly-computed EmbedResult instead of embedding twice.
+  const embeddingsDir = path.join(outputDir, "..", "embeddings");
+  const embedModelId = embedModel ?? DEFAULT_EMBED_MODEL;
+  let embedResult: EmbedResult | undefined;
+  if (embed) {
+    console.error(`\n[crune] Embedding chunks with ${embedModelId}...`);
+    try {
+      const backend = createTransformersBackend(embedModelId, DEFAULT_EMBED_DIM);
+      const embedInputs = toSessionInputs(parsedSessions);
+      embedResult = await embedSessions(embedInputs, backend, { model: embedModelId });
+      writeEmbeddingIndex(embeddingsDir, embedResult);
+      const binSize = embedResult.matrix.byteLength;
+      console.error(
+        `[crune] Wrote embeddings index: ${embedResult.count} chunks × ${embedResult.dim} dim (${(binSize / 1024).toFixed(1)} KB) → ${embeddingsDir}`
+      );
+    } catch (err) {
+      console.error(
+        `[crune] Embedding step failed (continuing without index): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // Retrieval-enriched synthesis context (issue #33, opt-in, default OFF).
+  // Build a hybrid retriever over the analyzed sessions. Falls back to the
+  // cluster-blob examples (retriever stays undefined) on any failure.
+  let synthesisRetriever: Retriever | undefined;
+  if (retrievalContext && !skipSynthesis) {
+    console.error(`\n[crune] Building retrieval context (issue #33)...`);
+    const built = await buildSynthesisRetriever(
+      toSessionInputs(parsedSessions),
+      embeddingsDir,
+      embedModelId,
+      embedResult
+    );
+    if (built) {
+      synthesisRetriever = built.retriever;
+      console.error(`[crune] Retrieval strategy: ${built.strategy} (${built.retriever.size} chunks)`);
+    }
+  }
+
   // overview.json
   const overviewData = await generateOverview(parsedSessions, {
     skip: skipSynthesis,
@@ -876,6 +1045,7 @@ async function main() {
     evalThreshold,
     useHumanFeedback,
     feedbackFile,
+    retriever: synthesisRetriever,
   });
   const overviewPath = path.join(outputDir, "overview.json");
   fs.writeFileSync(overviewPath, JSON.stringify(overviewData, null, 2));
@@ -883,28 +1053,6 @@ async function main() {
   console.error(
     `[crune] Wrote ${overviewPath} (${(overviewSize / 1024).toFixed(1)} KB)`
   );
-
-  // Optional: chunk-level embedding index for RAG retrieval (issue #32).
-  // Opt-in (default OFF). Promotion to default is gated on the PoC (#35).
-  if (embed) {
-    const model = embedModel ?? DEFAULT_EMBED_MODEL;
-    const embeddingsDir = path.join(outputDir, "..", "embeddings");
-    console.error(`\n[crune] Embedding chunks with ${model}...`);
-    try {
-      const backend = createTransformersBackend(model, DEFAULT_EMBED_DIM);
-      const embedInputs = toSessionInputs(parsedSessions);
-      const result = await embedSessions(embedInputs, backend, { model });
-      writeEmbeddingIndex(embeddingsDir, result);
-      const binSize = result.matrix.byteLength;
-      console.error(
-        `[crune] Wrote embeddings index: ${result.count} chunks × ${result.dim} dim (${(binSize / 1024).toFixed(1)} KB) → ${embeddingsDir}`
-      );
-    } catch (err) {
-      console.error(
-        `[crune] Embedding step failed (continuing without index): ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
 
   // Summary
   console.error(`\n[crune] --- Summary ---`);

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -19,18 +19,17 @@ import {
   type SemanticKnowledgeGraph,
   embedSessions,
   writeEmbeddingIndex,
-  readEmbeddingIndex,
   createTransformersBackend,
-  createRetriever,
-  createRetrieverFromIndex,
-  extractChunks,
-  dequantize,
   DEFAULT_EMBED_MODEL,
   DEFAULT_EMBED_DIM,
   type Retriever,
   type EmbedResult,
 } from "./knowledge-graph-builder.js";
-import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, buildRetrievalQuery, type SynthesisOptions, type HumanFeedbackSignal, type RetrievedChunk } from "./skill-synthesizer.js";
+import {
+  buildSynthesisRetriever,
+  retrieveContextForCandidate,
+} from "./knowledge-graph/synthesis-retriever.js";
+import { buildSynthesisPrompt, synthesizeWithClaude, stripSynthesisPreamble, type SynthesisOptions, type HumanFeedbackSignal, type RetrievedChunk } from "./skill-synthesizer.js";
 import { computeSessionHumanSignal } from "./knowledge-graph/reusability.js";
 import {
   readFeedbackFile,
@@ -338,9 +337,6 @@ interface SynthesisConfig {
   retriever?: Retriever;
 }
 
-/** Top-k turn snippets retrieved per candidate for synthesis context (#33). */
-const RETRIEVAL_TOP_K = 8;
-
 /**
  * Map parsed sessions onto the `SessionInput` shape consumed by the knowledge
  * graph builder and the embedding pipeline. Extracted so both the overview
@@ -386,88 +382,6 @@ function toSessionInputs(sessions: ParsedSession[]): SessionInput[] {
       subagentCount: s.meta.subagentCount,
     },
   }));
-}
-
-/**
- * Build a hybrid retriever for retrieval-enriched synthesis (issue #33).
- *
- * Strategy, in order of preference:
- *   1. Reuse an embedding index already computed this run (`precomputed`, from
- *      the `--embed` step) — zero extra model calls.
- *   2. Read an on-disk index at `embeddingsDir` (from a prior `--embed` run).
- *   3. Embed the analyzed sessions fresh via the production backend.
- *
- * BM25 needs the full chunk text, which the persisted meta.json does NOT store
- * (only the short snippet). We re-derive it with `extractChunks` (same order as
- * the index) and zip by index. Returns `null` (never throws) when no index and
- * no usable backend are available, so the caller falls back to the cluster blob.
- */
-async function buildSynthesisRetriever(
-  sessionInputs: SessionInput[],
-  embeddingsDir: string,
-  model: string,
-  precomputed?: EmbedResult
-): Promise<{ retriever: Retriever; strategy: string } | null> {
-  // extractChunks is the canonical chunk order shared with the embedder; its
-  // `text` field is what BM25 indexes.
-  const extracted = extractChunks(sessionInputs);
-  if (extracted.length === 0) {
-    console.error("[crune] Retrieval context: no chunks to index, falling back to cluster blob");
-    return null;
-  }
-  const chunkTexts = extracted.map((c) => c.text);
-
-  try {
-    const backend = createTransformersBackend(model, DEFAULT_EMBED_DIM);
-
-    // (1) Reuse embeddings computed earlier this run.
-    if (precomputed && precomputed.count === extracted.length) {
-      const retriever = createRetrieverFromIndex({
-        chunks: precomputed.chunks,
-        matrix: precomputed.matrix,
-        dim: precomputed.dim,
-        chunkTexts,
-        backend,
-      });
-      return { retriever, strategy: "reused --embed index (this run)" };
-    }
-
-    // (2) Reuse an index persisted by a prior run.
-    if (fs.existsSync(path.join(embeddingsDir, "meta.json"))) {
-      const { meta, matrix } = readEmbeddingIndex(embeddingsDir);
-      if (meta.count === extracted.length) {
-        const retriever = createRetrieverFromIndex({
-          chunks: meta.chunks,
-          matrix,
-          dim: meta.dim,
-          chunkTexts,
-          backend,
-        });
-        return { retriever, strategy: `on-disk index (${embeddingsDir})` };
-      }
-      console.error(
-        `[crune] Retrieval context: on-disk index count ${meta.count} != ${extracted.length} chunks, re-embedding`
-      );
-    }
-
-    // (3) Embed fresh in-memory.
-    const result = await embedSessions(sessionInputs, backend, { model });
-    const denseVectors = result.chunks.map((_, i) =>
-      dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
-    );
-    const retriever = createRetriever({
-      chunks: result.chunks,
-      texts: chunkTexts,
-      denseVectors,
-      backend,
-    });
-    return { retriever, strategy: "freshly embedded (in-memory)" };
-  } catch (err) {
-    console.error(
-      `[crune] Retrieval context unavailable (falling back to cluster blob): ${err instanceof Error ? err.message : String(err)}`
-    );
-    return null;
-  }
 }
 
 async function generateOverview(sessions: ParsedSession[], synthesisConfig: SynthesisConfig = { skip: false, count: 5 }): Promise<OverviewJson> {
@@ -746,24 +660,19 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
 
       // Retrieval-enriched context (issue #33). When a retriever is available,
       // pull the top-k most relevant turn snippets for this candidate; on any
-      // failure we leave `retrievedContext` undefined so buildSynthesisPrompt
-      // falls back to the cluster-blob examples (never crash).
+      // failure `retrieveContextForCandidate` returns undefined so
+      // buildSynthesisPrompt falls back to the cluster-blob examples (never crash).
       let retrievedContext: RetrievedChunk[] | undefined;
       if (synthesisConfig.retriever) {
-        try {
-          const query = buildRetrievalQuery(candidate, topic as unknown as import("./skill-synthesizer.js").TopicNode);
-          const chunks = await synthesisConfig.retriever.retrieve(query, RETRIEVAL_TOP_K);
-          if (chunks.length > 0) {
-            retrievedContext = chunks;
-            console.error(`[crune]   [${i + 1}/${total}] Retrieved ${chunks.length} relevant moments`);
-          } else {
-            console.error(`[crune]   [${i + 1}/${total}] No relevant moments retrieved, using cluster blob`);
-          }
-        } catch (err) {
-          console.error(
-            `[crune]   [${i + 1}/${total}] Retrieval failed (using cluster blob): ${err instanceof Error ? err.message : String(err)}`
-          );
-        }
+        retrievedContext = await retrieveContextForCandidate(synthesisConfig.retriever, candidate, {
+          label: topic.label,
+          keywords: topic.keywords,
+        });
+        console.error(
+          retrievedContext
+            ? `[crune]   [${i + 1}/${total}] Retrieved ${retrievedContext.length} relevant moments`
+            : `[crune]   [${i + 1}/${total}] No relevant moments retrieved, using cluster blob`
+        );
       }
 
       const prompt = buildSynthesisPrompt({

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -23,8 +23,20 @@ import {
   buildSynthesisPrompt,
   synthesizeWithClaude,
   stripSynthesisPreamble,
+  buildRetrievalQuery,
   type TopicNode as SynthTopicNode,
+  type RetrievedChunk,
 } from "./skill-synthesizer.js";
+import {
+  extractChunks,
+  embedSessions,
+  dequantize,
+  createRetriever,
+  createTransformersBackend,
+  DEFAULT_EMBED_MODEL,
+  DEFAULT_EMBED_DIM,
+  type Retriever,
+} from "./knowledge-graph-builder.js";
 import { evaluateSkill } from "./skill-evaluator.js";
 
 // ─── CLI argument parsing ─────────────────────────────────────────
@@ -40,6 +52,7 @@ interface CliArgs {
   json: boolean;
   skipEval: boolean;
   evalModel?: string;
+  retrievalContext: boolean;
 }
 
 export function parseCliArgs(argv: string[]): CliArgs {
@@ -54,6 +67,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
   let json = false;
   let skipEval = false;
   let evalModel: string | undefined;
+  let retrievalContext = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--sessions-dir" && args[i + 1]) {
@@ -77,13 +91,15 @@ export function parseCliArgs(argv: string[]): CliArgs {
       skipEval = true;
     } else if (args[i] === "--eval-model" && args[i + 1]) {
       evalModel = args[++i];
+    } else if (args[i] === "--retrieval-context") {
+      retrievalContext = true;
     } else if (args[i] === "--help" || args[i] === "-h") {
       printUsage();
       process.exit(0);
     }
   }
 
-  return { sessionsDir, outputDir, count, model, skipSynthesis, dryRun, preview, json, skipEval, evalModel };
+  return { sessionsDir, outputDir, count, model, skipSynthesis, dryRun, preview, json, skipEval, evalModel, retrievalContext };
 }
 
 function printUsage(): void {
@@ -103,6 +119,8 @@ Options:
                          stdout (see README "JSON output schema")
   --skip-eval            Skip skill evaluation pipeline (structural + rubric)
   --eval-model <model>   Claude model for rubric scoring (defaults to --model)
+  --retrieval-context    Enrich synthesis with hybrid-retrieved relevant moments
+                         instead of the cluster-blob examples (opt-in, issue #33)
   -h, --help             Show this help message`);
 }
 
@@ -320,6 +338,37 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  // Retrieval-enriched synthesis context (issue #33, opt-in). Build an
+  // in-memory hybrid retriever over the analyzed sessions; on any failure we
+  // fall back to the cluster-blob examples (retriever stays undefined).
+  let retriever: Retriever | undefined;
+  if (config.retrievalContext && !config.skipSynthesis) {
+    console.error("\nBuilding retrieval context (issue #33)...");
+    try {
+      const extracted = extractChunks(sessionInputs);
+      if (extracted.length === 0) {
+        console.error("  No chunks to index — falling back to cluster blob");
+      } else {
+        const backend = createTransformersBackend(DEFAULT_EMBED_MODEL, DEFAULT_EMBED_DIM);
+        const result = await embedSessions(sessionInputs, backend, { model: DEFAULT_EMBED_MODEL });
+        const denseVectors = result.chunks.map((_, i) =>
+          dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
+        );
+        retriever = createRetriever({
+          chunks: result.chunks,
+          texts: extracted.map((c) => c.text),
+          denseVectors,
+          backend,
+        });
+        console.error(`  Retrieval strategy: freshly embedded (in-memory), ${retriever.size} chunks`);
+      }
+    } catch (err) {
+      console.error(
+        `  Retrieval context unavailable (falling back to cluster blob): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
   // Synthesize skills. In preview mode we emit markdown to stdout instead of
   // writing files, but evaluation still runs by default.
   const writeToDisk = !config.preview;
@@ -344,10 +393,31 @@ async function main(): Promise<void> {
         (seq) => seq.sessionIds.some((sid) => topicSessionSet.has(sid))
       );
 
+      // Retrieve top-k relevant moments for this candidate (issue #33). On any
+      // failure, leave undefined so the cluster-blob examples are used.
+      let retrievedContext: RetrievedChunk[] | undefined;
+      if (retriever) {
+        try {
+          const query = buildRetrievalQuery(candidate, topic as unknown as SynthTopicNode);
+          const chunks = await retriever.retrieve(query, 8);
+          if (chunks.length > 0) retrievedContext = chunks;
+        } catch (err) {
+          console.error(
+            `    Retrieval failed (using cluster blob): ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+
+      // Surface the chosen context strategy so a human can A/B blob vs retrieval.
+      console.error(
+        `    Context strategy: ${retrievedContext ? `retrieval (${retrievedContext.length} moments)` : "cluster blob"}`
+      );
+
       const prompt = buildSynthesisPrompt({
         skillCandidate: candidate,
         topicNode: topic as unknown as SynthTopicNode,
         enrichedSequences: relatedSequences,
+        retrievedContext,
       });
 
       const result = await synthesizeWithClaude(prompt, {

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -23,20 +23,17 @@ import {
   buildSynthesisPrompt,
   synthesizeWithClaude,
   stripSynthesisPreamble,
-  buildRetrievalQuery,
   type TopicNode as SynthTopicNode,
   type RetrievedChunk,
 } from "./skill-synthesizer.js";
 import {
-  extractChunks,
-  embedSessions,
-  dequantize,
-  createRetriever,
-  createTransformersBackend,
   DEFAULT_EMBED_MODEL,
-  DEFAULT_EMBED_DIM,
   type Retriever,
 } from "./knowledge-graph-builder.js";
+import {
+  buildSynthesisRetriever,
+  retrieveContextForCandidate,
+} from "./knowledge-graph/synthesis-retriever.js";
 import { evaluateSkill } from "./skill-evaluator.js";
 
 // ─── CLI argument parsing ─────────────────────────────────────────
@@ -338,34 +335,21 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Retrieval-enriched synthesis context (issue #33, opt-in). Build an
-  // in-memory hybrid retriever over the analyzed sessions; on any failure we
-  // fall back to the cluster-blob examples (retriever stays undefined).
+  // Retrieval-enriched synthesis context (issue #33, opt-in). Build a hybrid
+  // retriever over the analyzed sessions via the shared helper (reuses an
+  // on-disk index if one exists under outputDir, else embeds fresh). On any
+  // failure the retriever stays undefined and synthesis falls back to the blob.
   let retriever: Retriever | undefined;
   if (config.retrievalContext && !config.skipSynthesis) {
     console.error("\nBuilding retrieval context (issue #33)...");
-    try {
-      const extracted = extractChunks(sessionInputs);
-      if (extracted.length === 0) {
-        console.error("  No chunks to index — falling back to cluster blob");
-      } else {
-        const backend = createTransformersBackend(DEFAULT_EMBED_MODEL, DEFAULT_EMBED_DIM);
-        const result = await embedSessions(sessionInputs, backend, { model: DEFAULT_EMBED_MODEL });
-        const denseVectors = result.chunks.map((_, i) =>
-          dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
-        );
-        retriever = createRetriever({
-          chunks: result.chunks,
-          texts: extracted.map((c) => c.text),
-          denseVectors,
-          backend,
-        });
-        console.error(`  Retrieval strategy: freshly embedded (in-memory), ${retriever.size} chunks`);
-      }
-    } catch (err) {
-      console.error(
-        `  Retrieval context unavailable (falling back to cluster blob): ${err instanceof Error ? err.message : String(err)}`
-      );
+    const built = await buildSynthesisRetriever(
+      sessionInputs,
+      path.join(config.outputDir, "embeddings"),
+      DEFAULT_EMBED_MODEL
+    );
+    if (built) {
+      retriever = built.retriever;
+      console.error(`  Retrieval strategy: ${built.strategy}, ${retriever.size} chunks`);
     }
   }
 
@@ -394,18 +378,14 @@ async function main(): Promise<void> {
       );
 
       // Retrieve top-k relevant moments for this candidate (issue #33). On any
-      // failure, leave undefined so the cluster-blob examples are used.
+      // failure `retrieveContextForCandidate` returns undefined so the
+      // cluster-blob examples are used.
       let retrievedContext: RetrievedChunk[] | undefined;
       if (retriever) {
-        try {
-          const query = buildRetrievalQuery(candidate, topic as unknown as SynthTopicNode);
-          const chunks = await retriever.retrieve(query, 8);
-          if (chunks.length > 0) retrievedContext = chunks;
-        } catch (err) {
-          console.error(
-            `    Retrieval failed (using cluster blob): ${err instanceof Error ? err.message : String(err)}`
-          );
-        }
+        retrievedContext = await retrieveContextForCandidate(retriever, candidate, {
+          label: topic.label,
+          keywords: topic.keywords,
+        });
       }
 
       // Surface the chosen context strategy so a human can A/B blob vs retrieval.

--- a/scripts/knowledge-graph/synthesis-retriever.ts
+++ b/scripts/knowledge-graph/synthesis-retriever.ts
@@ -22,6 +22,7 @@ import {
   createRetrieverFromIndex,
   DEFAULT_EMBED_DIM,
   type SessionInput,
+  type ChunkMeta,
   type EmbedResult,
   type Retriever,
   type RetrievedChunk,
@@ -31,6 +32,29 @@ import type { SkillCandidate } from "./types.js";
 
 /** Top-k turn snippets retrieved per candidate for synthesis context (#33). */
 export const RETRIEVAL_TOP_K = 8;
+
+/**
+ * Verify that an existing int8 index lines up with freshly re-extracted chunks
+ * by IDENTITY, not just count. A stale index with a coincidentally-equal chunk
+ * count would otherwise be zipped with fresh `chunkTexts` from unrelated
+ * sessions — grounding synthesis on the wrong conversation moments.
+ *
+ * We compare `sessionId`/`turnIndex` for every chunk (extractChunks is the
+ * canonical, deterministic order shared with the embedder), so any drift —
+ * inserted, removed, or reordered sessions — is caught.
+ */
+function chunksAlign(indexed: ChunkMeta[], extracted: ChunkMeta[]): boolean {
+  if (indexed.length !== extracted.length) return false;
+  for (let i = 0; i < indexed.length; i++) {
+    if (
+      indexed[i].sessionId !== extracted[i].sessionId ||
+      indexed[i].turnIndex !== extracted[i].turnIndex
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /**
  * Build a hybrid retriever for retrieval-enriched synthesis (issue #33).
@@ -43,8 +67,11 @@ export const RETRIEVAL_TOP_K = 8;
  *
  * BM25 needs the full chunk text, which the persisted meta.json does NOT store
  * (only the short snippet). We re-derive it with `extractChunks` (same order as
- * the index) and zip by index. Returns `null` (never throws) when no index and
- * no usable backend are available, so the caller falls back to the cluster blob.
+ * the index) and zip by index — but only after confirming the index chunks
+ * align with the re-extracted chunks by IDENTITY (not just count). On mismatch
+ * we fall through to a fresh embed rather than grounding on stale data. Returns
+ * `null` (never throws) when no index and no usable backend are available, so
+ * the caller falls back to the cluster blob.
  */
 export async function buildSynthesisRetriever(
   sessionInputs: SessionInput[],
@@ -65,7 +92,7 @@ export async function buildSynthesisRetriever(
     const backend = createTransformersBackend(model, DEFAULT_EMBED_DIM);
 
     // (1) Reuse embeddings computed earlier this run.
-    if (precomputed && precomputed.count === extracted.length) {
+    if (precomputed && chunksAlign(precomputed.chunks, extracted)) {
       const retriever = createRetrieverFromIndex({
         chunks: precomputed.chunks,
         matrix: precomputed.matrix,
@@ -76,10 +103,13 @@ export async function buildSynthesisRetriever(
       return { retriever, strategy: "reused --embed index (this run)" };
     }
 
-    // (2) Reuse an index persisted by a prior run.
+    // (2) Reuse an index persisted by a prior run — only when its chunks align
+    // with the re-extracted chunks by identity (stale-index guard). A matching
+    // count alone is not enough: a coincidentally-equal count would zip stale
+    // vectors with fresh, unrelated chunkTexts.
     if (fs.existsSync(path.join(embeddingsDir, "meta.json"))) {
       const { meta, matrix } = readEmbeddingIndex(embeddingsDir);
-      if (meta.count === extracted.length) {
+      if (chunksAlign(meta.chunks, extracted)) {
         const retriever = createRetrieverFromIndex({
           chunks: meta.chunks,
           matrix,
@@ -90,7 +120,7 @@ export async function buildSynthesisRetriever(
         return { retriever, strategy: `on-disk index (${embeddingsDir})` };
       }
       console.error(
-        `[crune] Retrieval context: on-disk index count ${meta.count} != ${extracted.length} chunks, re-embedding`
+        `[crune] Retrieval context: on-disk index (${meta.count} chunks) does not align with ${extracted.length} re-extracted chunks, re-embedding`
       );
     }
 

--- a/scripts/knowledge-graph/synthesis-retriever.ts
+++ b/scripts/knowledge-graph/synthesis-retriever.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared retrieval-enriched synthesis helpers (issue #33).
+ *
+ * Both the data pipeline (`analyze-sessions.ts`) and the npx CLI (`cli.ts`) build
+ * a hybrid retriever over the analyzed sessions and, per skill candidate, pull
+ * the top-k most relevant turn snippets to ground synthesis. The build strategy
+ * and the per-candidate retrieve-with-fallback loop were independently
+ * re-implemented in both entry points; this module is the single source of truth.
+ *
+ * Nothing here throws to the caller: `buildSynthesisRetriever` returns `null`
+ * and `retrieveContextForCandidate` returns `undefined` on any failure, so the
+ * caller transparently falls back to the loosely-related cluster blob.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  extractChunks,
+  embedSessions,
+  readEmbeddingIndex,
+  createTransformersBackend,
+  createRetriever,
+  createRetrieverFromIndex,
+  dequantize,
+  DEFAULT_EMBED_DIM,
+  type SessionInput,
+  type EmbedResult,
+  type Retriever,
+  type RetrievedChunk,
+} from "./index.js";
+import { buildRetrievalQuery } from "../skill-synthesizer.js";
+import type { SkillCandidate } from "./types.js";
+
+/** Top-k turn snippets retrieved per candidate for synthesis context (#33). */
+export const RETRIEVAL_TOP_K = 8;
+
+/**
+ * Build a hybrid retriever for retrieval-enriched synthesis (issue #33).
+ *
+ * Strategy, in order of preference:
+ *   1. Reuse an embedding index already computed this run (`precomputed`, from
+ *      the `--embed` step) — zero extra model calls.
+ *   2. Read an on-disk index at `embeddingsDir` (from a prior `--embed` run).
+ *   3. Embed the analyzed sessions fresh via the production backend.
+ *
+ * BM25 needs the full chunk text, which the persisted meta.json does NOT store
+ * (only the short snippet). We re-derive it with `extractChunks` (same order as
+ * the index) and zip by index. Returns `null` (never throws) when no index and
+ * no usable backend are available, so the caller falls back to the cluster blob.
+ */
+export async function buildSynthesisRetriever(
+  sessionInputs: SessionInput[],
+  embeddingsDir: string,
+  model: string,
+  precomputed?: EmbedResult
+): Promise<{ retriever: Retriever; strategy: string } | null> {
+  // extractChunks is the canonical chunk order shared with the embedder; its
+  // `text` field is what BM25 indexes.
+  const extracted = extractChunks(sessionInputs);
+  if (extracted.length === 0) {
+    console.error("[crune] Retrieval context: no chunks to index, falling back to cluster blob");
+    return null;
+  }
+  const chunkTexts = extracted.map((c) => c.text);
+
+  try {
+    const backend = createTransformersBackend(model, DEFAULT_EMBED_DIM);
+
+    // (1) Reuse embeddings computed earlier this run.
+    if (precomputed && precomputed.count === extracted.length) {
+      const retriever = createRetrieverFromIndex({
+        chunks: precomputed.chunks,
+        matrix: precomputed.matrix,
+        dim: precomputed.dim,
+        chunkTexts,
+        backend,
+      });
+      return { retriever, strategy: "reused --embed index (this run)" };
+    }
+
+    // (2) Reuse an index persisted by a prior run.
+    if (fs.existsSync(path.join(embeddingsDir, "meta.json"))) {
+      const { meta, matrix } = readEmbeddingIndex(embeddingsDir);
+      if (meta.count === extracted.length) {
+        const retriever = createRetrieverFromIndex({
+          chunks: meta.chunks,
+          matrix,
+          dim: meta.dim,
+          chunkTexts,
+          backend,
+        });
+        return { retriever, strategy: `on-disk index (${embeddingsDir})` };
+      }
+      console.error(
+        `[crune] Retrieval context: on-disk index count ${meta.count} != ${extracted.length} chunks, re-embedding`
+      );
+    }
+
+    // (3) Embed fresh in-memory.
+    const result = await embedSessions(sessionInputs, backend, { model });
+    const denseVectors = result.chunks.map((_, i) =>
+      dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
+    );
+    const retriever = createRetriever({
+      chunks: result.chunks,
+      texts: chunkTexts,
+      denseVectors,
+      backend,
+    });
+    return { retriever, strategy: "freshly embedded (in-memory)" };
+  } catch (err) {
+    console.error(
+      `[crune] Retrieval context unavailable (falling back to cluster blob): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Retrieve the top-k relevant turn snippets for a single skill candidate
+ * (issue #33). Builds the hybrid query from the candidate + topic, retrieves,
+ * and on ANY failure (or empty result) returns `undefined` so the caller falls
+ * back to the cluster-blob examples — never crashes synthesis.
+ */
+export async function retrieveContextForCandidate(
+  retriever: Retriever,
+  candidate: Pick<SkillCandidate, "skillMarkdown">,
+  topic: { label: string; keywords: string[] }
+): Promise<RetrievedChunk[] | undefined> {
+  try {
+    const query = buildRetrievalQuery(candidate, topic);
+    const chunks = await retriever.retrieve(query, RETRIEVAL_TOP_K);
+    return chunks.length > 0 ? chunks : undefined;
+  } catch (err) {
+    console.error(
+      `[crune] Retrieval failed (using cluster blob): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return undefined;
+  }
+}

--- a/scripts/knowledge-graph/synthesis-retriever.ts
+++ b/scripts/knowledge-graph/synthesis-retriever.ts
@@ -19,9 +19,7 @@ import {
   embedSessions,
   readEmbeddingIndex,
   createTransformersBackend,
-  createRetriever,
   createRetrieverFromIndex,
-  dequantize,
   DEFAULT_EMBED_DIM,
   type SessionInput,
   type EmbedResult,
@@ -96,15 +94,14 @@ export async function buildSynthesisRetriever(
       );
     }
 
-    // (3) Embed fresh in-memory.
+    // (3) Embed fresh in-memory. createRetrieverFromIndex owns the dequantize
+    // step AND the chunks/matrix/chunkTexts length-consistency guard.
     const result = await embedSessions(sessionInputs, backend, { model });
-    const denseVectors = result.chunks.map((_, i) =>
-      dequantize(result.matrix.subarray(i * result.dim, (i + 1) * result.dim))
-    );
-    const retriever = createRetriever({
+    const retriever = createRetrieverFromIndex({
       chunks: result.chunks,
-      texts: chunkTexts,
-      denseVectors,
+      matrix: result.matrix,
+      dim: result.dim,
+      chunkTexts,
       backend,
     });
     return { retriever, strategy: "freshly embedded (in-memory)" };

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process";
 
+// Canonical retrieved-chunk shape lives with the hybrid retriever (issue #32);
+// re-export it (type-only = no runtime coupling to the embedding pipeline) so
+// this module's public API is unchanged while there is a single definition.
+import type { RetrievedChunk } from "./knowledge-graph/retriever.js";
+export type { RetrievedChunk } from "./knowledge-graph/retriever.js";
+
 // ---------- Types ----------
 
 export interface ToolSignatureEntry {
@@ -69,18 +75,6 @@ export interface FacetsInsightsSummary {
   helpfulnessScore: number;
   commonFrictions: string[];
   frictionDetails: string[];
-}
-
-/**
- * A retrieved conversation moment threaded into synthesis (issue #33). Mirrors
- * `RetrievedChunk` from the hybrid retriever (issue #32) — duplicated here so
- * this module stays free of any embedding/retriever imports.
- */
-export interface RetrievedChunk {
-  sessionId: string;
-  turnIndex: number;
-  snippet: string;
-  score: number;
 }
 
 /**

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -357,28 +357,30 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     `7. Output ONLY the markdown content. No code fences wrapping the output, no explanations before or after.`,
   ];
 
-  // Rules 1-7 are fixed; additional conditional rules are numbered sequentially.
-  let nextRule = 8;
-  if (graphContext && graphContext.connectedTopics.some(ct => ct.edgeType === "workflow-continuation")) {
-    instructionLines.push(`${nextRule++}. If workflow-continuation connections exist, include \`requires\` and/or \`next\` fields in the YAML frontmatter listing the connected topic labels.`);
-  }
-
-  // --- Retrieved relevant moments rule (issue #33) ---
-  // Redirect the "examples" expectation (rules 3/4 say "representative prompts")
-  // to the precisely-scoped retrieved moments that replaced the blob.
-  if (useRetrieval) {
-    instructionLines.push(
-      `${nextRule++}. Ground "When to Use" triggers and "Workflow" steps in the **Retrieved Relevant Moments** above: these are the most relevant turns to this skill. Draw concrete examples from them instead of the generic patterns.`,
-    );
-  }
-
-  // --- Human-flagged moments section (issue #24) ---
   const humanFeedbackSection = buildHumanFeedbackSection(humanFeedback ?? []);
-  if (humanFeedbackSection) {
-    instructionLines.push(
-      `${nextRule}. Prioritize the **Human-Flagged Moments** above: replicate the \`reusable\` approaches and explicitly steer away from the \`anti-pattern\` ones. These are direct human signals and outrank heuristic inferences.`,
-    );
-  }
+
+  // Rules 1-7 are fixed; the conditional rules below are collected as bodies,
+  // filtered for the ones that apply, and numbered in a single pass so adding
+  // or reordering a rule never desyncs the counter.
+  const conditionalRuleBodies: (string | false | undefined)[] = [
+    // Workflow-continuation frontmatter (graph context).
+    (graphContext && graphContext.connectedTopics.some((ct) => ct.edgeType === "workflow-continuation")) &&
+      "If workflow-continuation connections exist, include `requires` and/or `next` fields in the YAML frontmatter listing the connected topic labels.",
+    // Retrieved relevant moments rule (issue #33). Redirect the "examples"
+    // expectation (rules 3/4 say "representative prompts") to the
+    // precisely-scoped retrieved moments that replaced the blob.
+    useRetrieval &&
+      'Ground "When to Use" triggers and "Workflow" steps in the **Retrieved Relevant Moments** above: these are the most relevant turns to this skill. Draw concrete examples from them instead of the generic patterns.',
+    // Human-flagged moments rule (issue #24).
+    humanFeedbackSection &&
+      "Prioritize the **Human-Flagged Moments** above: replicate the `reusable` approaches and explicitly steer away from the `anti-pattern` ones. These are direct human signals and outrank heuristic inferences.",
+  ];
+  const FIRST_CONDITIONAL_RULE = 8; // rules 1-7 are fixed above
+  conditionalRuleBodies
+    .filter((body): body is string => Boolean(body))
+    .forEach((body, idx) => {
+      instructionLines.push(`${FIRST_CONDITIONAL_RULE + idx}. ${body}`);
+    });
 
   const instruction = instructionLines.join("\n");
 

--- a/scripts/skill-synthesizer.ts
+++ b/scripts/skill-synthesizer.ts
@@ -72,6 +72,18 @@ export interface FacetsInsightsSummary {
 }
 
 /**
+ * A retrieved conversation moment threaded into synthesis (issue #33). Mirrors
+ * `RetrievedChunk` from the hybrid retriever (issue #32) — duplicated here so
+ * this module stays free of any embedding/retriever imports.
+ */
+export interface RetrievedChunk {
+  sessionId: string;
+  turnIndex: number;
+  snippet: string;
+  score: number;
+}
+
+/**
  * A human-flagged playback moment threaded into synthesis (issue #24). The
  * caller resolves a short snippet for the turn; this module only formats it.
  */
@@ -96,6 +108,13 @@ export interface SynthesisRequest {
   facetsInsights?: FacetsInsightsSummary;
   /** Human-flagged moments (issue #24); present only with --use-human-feedback. */
   humanFeedback?: HumanFeedbackSignal[];
+  /**
+   * Hybrid-retrieved relevant moments (issue #33); present only with
+   * --retrieval-context. When non-empty, the "Retrieved Relevant Moments"
+   * section REPLACES the loosely-related cluster-blob examples (representative
+   * prompts + enriched tool patterns).
+   */
+  retrievedContext?: RetrievedChunk[];
 }
 
 export interface SynthesisResponse {
@@ -153,8 +172,56 @@ export function buildHumanFeedbackSection(signals: HumanFeedbackSignal[]): strin
   return lines.join("\n");
 }
 
+/** Max characters of the heuristic skillMarkdown folded into a retrieval query. */
+const RETRIEVAL_QUERY_MARKDOWN_MAX = 600;
+
+/**
+ * Build a hybrid-retrieval query for a skill candidate (issue #33). Combines the
+ * topic label, top keywords, and a truncated slice of the heuristic
+ * `skillMarkdown` so the dense + BM25 signals both have material to match. Pure
+ * and side-effect free so it can be unit-tested without a retriever.
+ */
+export function buildRetrievalQuery(
+  candidate: Pick<SkillCandidate, "skillMarkdown">,
+  topic: Pick<TopicNode, "label" | "keywords">
+): string {
+  const label = topic.label?.trim() ?? "";
+  const keywords = (topic.keywords ?? []).join(" ").trim();
+  const markdown = (candidate.skillMarkdown ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, RETRIEVAL_QUERY_MARKDOWN_MAX);
+  return [label, keywords, markdown].filter(Boolean).join(" ").trim();
+}
+
+/**
+ * Render the "Retrieved Relevant Moments" section from hybrid-retrieved chunks
+ * (issue #33). Each line carries `sessionId#turnIndex`, the snippet, and the
+ * blended retrieval score so the model can weigh relevance. Returns "" when
+ * there is nothing to report (caller then falls back to the cluster blob).
+ */
+export function buildRetrievedMomentsSection(chunks: RetrievedChunk[]): string {
+  if (!chunks || chunks.length === 0) return "";
+
+  const lines = [
+    `## Retrieved Relevant Moments (hybrid retrieval)`,
+    `These conversation turns were retrieved as the most relevant to this skill via hybrid (dense + BM25) search. They are tightly scoped to the workflow — prefer them over generic patterns when shaping concrete steps and examples.`,
+    ...chunks.map(
+      (c) => `- [${c.sessionId}#${c.turnIndex}] (score: ${c.score.toFixed(3)}) ${c.snippet}`
+    ),
+  ];
+
+  return lines.join("\n");
+}
+
 export function buildSynthesisPrompt(body: SynthesisRequest): string {
-  const { skillCandidate, topicNode, enrichedSequences, graphContext, facetsInsights, humanFeedback } = body;
+  const { skillCandidate, topicNode, enrichedSequences, graphContext, facetsInsights, humanFeedback, retrievedContext } = body;
+
+  // When retrieval context is present, the precisely-scoped "Retrieved Relevant
+  // Moments" section REPLACES the loosely-related cluster blob (representative
+  // prompts + enriched tool patterns). Otherwise we keep the blob (issue #33 A/B).
+  const retrievedMomentsSection = buildRetrievedMomentsSection(retrievedContext ?? []);
+  const useRetrieval = retrievedMomentsSection !== "";
 
   const topicInfo = [
     `## Topic Information`,
@@ -166,7 +233,9 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     `- **Total Duration:** ${topicNode.totalDurationMinutes} minutes`,
   ].join("\n");
 
-  const prompts = topicNode.representativePrompts.length > 0
+  // Cluster-blob examples (representative prompts) — suppressed when retrieval
+  // context replaces them.
+  const prompts = !useRetrieval && topicNode.representativePrompts.length > 0
     ? [
         `## Representative User Prompts`,
         ...topicNode.representativePrompts.map((p, i) => `${i + 1}. ${p}`),
@@ -180,8 +249,10 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     ),
   ].join("\n");
 
+  // Cluster-blob examples (enriched tool patterns) — suppressed when retrieval
+  // context replaces them.
   let toolPatterns = "";
-  if (enrichedSequences && enrichedSequences.length > 0) {
+  if (!useRetrieval && enrichedSequences && enrichedSequences.length > 0) {
     const top5 = enrichedSequences.slice(0, 5);
     const flows = top5.map((seq) => {
       const flow = seq.sequence.map((s) => s.toolName).join(" → ");
@@ -298,6 +369,15 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     instructionLines.push(`${nextRule++}. If workflow-continuation connections exist, include \`requires\` and/or \`next\` fields in the YAML frontmatter listing the connected topic labels.`);
   }
 
+  // --- Retrieved relevant moments rule (issue #33) ---
+  // Redirect the "examples" expectation (rules 3/4 say "representative prompts")
+  // to the precisely-scoped retrieved moments that replaced the blob.
+  if (useRetrieval) {
+    instructionLines.push(
+      `${nextRule++}. Ground "When to Use" triggers and "Workflow" steps in the **Retrieved Relevant Moments** above: these are the most relevant turns to this skill. Draw concrete examples from them instead of the generic patterns.`,
+    );
+  }
+
   // --- Human-flagged moments section (issue #24) ---
   const humanFeedbackSection = buildHumanFeedbackSection(humanFeedback ?? []);
   if (humanFeedbackSection) {
@@ -329,7 +409,7 @@ export function buildSynthesisPrompt(body: SynthesisRequest): string {
     facetsSection = lines.join("\n");
   }
 
-  const parts = [topicInfo, prompts, toolSig, toolPatterns, graphPosition, connectedTopicsSection, facetsSection, humanFeedbackSection, reference, instruction].filter(Boolean);
+  const parts = [topicInfo, prompts, retrievedMomentsSection, toolSig, toolPatterns, graphPosition, connectedTopicsSection, facetsSection, humanFeedbackSection, reference, instruction].filter(Boolean);
   return parts.join("\n\n");
 }
 


### PR DESCRIPTION
Closes #33 (Wave 5 — replace cluster-blob synthesis context with hybrid retrieval).

## What
For each `SkillCandidate`, hybrid retrieval (dense + BM25 from #32) selects the top-k most relevant turns, replacing the loose "Representative User Prompts + Enriched Tool Patterns" blob with a precise **Retrieved Relevant Moments** section + a grounding rule. Opt-in via `--retrieval-context` (default OFF for clean A/B), composes with `--preview`.

- `RetrievedChunk` + `retrievedContext` on `SynthesisRequest`; pure `buildRetrievalQuery` / `buildRetrievedMomentsSection`.
- Wired into both `analyze-sessions.ts` and `cli.ts`; falls back to the cluster blob (never crashes) when no index / embed fails.

## Review fixes (/nirami + /code-review, one commit each)
- **Shared `synthesis-retriever.ts`** — `analyze-sessions` and `cli` no longer duplicate the retriever build + per-candidate retrieve loop (a real A/B-divergence bug: cli hardcoded k=8, skipped index reuse). Single `RETRIEVAL_TOP_K`; cli now also reuses an on-disk index.
- **`createRetrieverFromIndex`** for the fresh-embed strategy — drops the hand-rolled dequantize loop and inherits its length guard.
- **Chunk-identity freshness check** (`chunksAlign`) — index reuse now verifies `sessionId`/`turnIndex` per chunk, not just count, so a stale index with an equal chunk count can't ground synthesis on unrelated sessions.
- **`RetrievedChunk` dedup** — type-only re-export from the canonical retriever definition (was hand-copied).
- **Removed `as unknown as TopicNode` casts** at `buildRetrievalQuery` sites (pass `{label, keywords}`).
- **Conditional rule numbering** collected + numbered in one pass (no `nextRule++` asymmetry).
- **Tests** — retriever-throws → blob fallback; loosened the brittle exact-top-1 blend assertion to a relative one.

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ 658/658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)