### PR TITLE
feat(playback): show Session ID in the Session Info panel

### DIFF
--- a/src/components/playback/PlaybackSidePanel.tsx
+++ b/src/components/playback/PlaybackSidePanel.tsx
@@ -97,6 +97,12 @@ export function PlaybackSidePanel({ detail }: Props) {
               <h3 className="side-section-title">Session Info</h3>
               <dl className="side-info-list">
                 <div className="side-info-item">
+                  <dt>Session ID</dt>
+                  <dd className="side-info-mono" title={detail.sessionId}>
+                    {detail.sessionId}
+                  </dd>
+                </div>
+                <div className="side-info-item">
                   <dt>Project</dt>
                   <dd>{meta.project}</dd>
                 </div>


### PR DESCRIPTION
Small QoL: display `detail.sessionId` at the top of the **Session Info** list in the playback side panel (mono, selectable, full value on hover) so it's easy to copy while looking at a session.

UI-only / no logic. `tsc -b` ✅ · `eslint` ✅ (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)