### PR TITLE
feat(#73): persist a compact facets summary on each topic

### DIFF
--- a/scripts/__tests__/facets-reader.test.ts
+++ b/scripts/__tests__/facets-reader.test.ts
@@ -5,8 +5,9 @@ import {
   helpfulnessToScore,
   aggregateFacetsForTopic,
   buildTopicFacetsSummary,
+  attachFacetsSummaries,
 } from "../knowledge-graph-builder.js";
-import type { FacetsInsightsSummary } from "../knowledge-graph/types.js";
+import type { FacetsInsightsSummary, TopicNode } from "../knowledge-graph/types.js";
 
 describe("normalizeGoalCategory", () => {
   it("maps feature_implementation → feature", () => {
@@ -251,5 +252,60 @@ describe("buildTopicFacetsSummary", () => {
     expect(
       buildTopicFacetsSummary(agg({ normalizedCategories: [], aggregatedGoals: [] }))
     ).toBeUndefined();
+  });
+
+  // The empty-signal guard is AND, not OR: a summary with only one side empty
+  // is still kept (pin the semantics so a future `||` regression is caught).
+  it("keeps the summary when only categories are empty", () => {
+    expect(buildTopicFacetsSummary(agg({ normalizedCategories: [] }))).toEqual({
+      categories: [],
+      goals: ["ship the feature"],
+      successRate: 0.8,
+      helpfulness: 0.6,
+    });
+  });
+
+  it("keeps the summary when only goals are empty", () => {
+    expect(buildTopicFacetsSummary(agg({ aggregatedGoals: [] }))).toEqual({
+      categories: ["feature", "testing"],
+      goals: [],
+      successRate: 0.8,
+      helpfulness: 0.6,
+    });
+  });
+});
+
+describe("attachFacetsSummaries", () => {
+  function node(sessionIds: string[]): TopicNode {
+    return { id: "t", sessionIds } as unknown as TopicNode;
+  }
+  function facets(sessionId: string): FacetsData {
+    return {
+      sessionId,
+      underlyingGoal: "Fix the bug",
+      goalCategories: { bug_fix: 1 },
+      outcome: "fully_achieved",
+      claudeHelpfulness: "very_helpful",
+      sessionType: "debugging",
+      frictionCounts: {},
+      frictionDetail: "",
+      primarySuccess: "",
+      briefSummary: "",
+    };
+  }
+
+  it("attaches a summary to topics whose sessions have facets", () => {
+    const nodes = [node(["s1", "s2"]), node(["s9"])]; // s9 has no facets
+    const map = new Map<string, FacetsData>([["s1", facets("s1")]]);
+    attachFacetsSummaries(nodes, map);
+    expect(nodes[0].facetsSummary?.categories).toContain("bugfix");
+    expect(nodes[1].facetsSummary).toBeUndefined();
+  });
+
+  it("is a no-op when the facets map is absent or empty", () => {
+    const nodes = [node(["s1"])];
+    attachFacetsSummaries(nodes, undefined);
+    attachFacetsSummaries(nodes, new Map());
+    expect(nodes[0].facetsSummary).toBeUndefined();
   });
 });

--- a/scripts/__tests__/facets-reader.test.ts
+++ b/scripts/__tests__/facets-reader.test.ts
@@ -4,7 +4,9 @@ import {
   normalizeGoalCategory,
   helpfulnessToScore,
   aggregateFacetsForTopic,
+  buildTopicFacetsSummary,
 } from "../knowledge-graph-builder.js";
+import type { FacetsInsightsSummary } from "../knowledge-graph/types.js";
 
 describe("normalizeGoalCategory", () => {
   it("maps feature_implementation → feature", () => {
@@ -218,5 +220,36 @@ describe("aggregateFacetsForTopic", () => {
     expect(result!.successRate).toBe(0.75);
     // helpfulnessScore: (1.0 + 0.5) / 2 = 0.75
     expect(result!.helpfulnessScore).toBe(0.75);
+  });
+});
+
+describe("buildTopicFacetsSummary", () => {
+  const agg = (over: Partial<FacetsInsightsSummary> = {}): FacetsInsightsSummary => ({
+    aggregatedGoals: ["ship the feature"],
+    normalizedCategories: ["feature", "testing"],
+    successRate: 0.8,
+    helpfulnessScore: 0.6,
+    commonFrictions: [],
+    frictionDetails: [],
+    ...over,
+  });
+
+  it("maps the compact subset for the UI", () => {
+    expect(buildTopicFacetsSummary(agg())).toEqual({
+      categories: ["feature", "testing"],
+      goals: ["ship the feature"],
+      successRate: 0.8,
+      helpfulness: 0.6,
+    });
+  });
+
+  it("returns undefined for no aggregation (no facets matched)", () => {
+    expect(buildTopicFacetsSummary(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no category or goal signal", () => {
+    expect(
+      buildTopicFacetsSummary(agg({ normalizedCategories: [], aggregatedGoals: [] }))
+    ).toBeUndefined();
   });
 });

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -15,7 +15,7 @@ import {
   buildSemanticKnowledgeGraph,
   readFacetsDir,
   aggregateFacetsForTopic,
-  buildTopicFacetsSummary,
+  attachFacetsSummaries,
   type SessionInput,
   type SemanticKnowledgeGraph,
   embedSessions,
@@ -526,22 +526,15 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
     humanSignalMap: synthesisConfig.useHumanFeedback ? humanSignalMap : undefined,
   });
 
-  // Read facets once and reuse for both topic-level filtering metadata (#73)
-  // and the synthesis loop below.
+  // Read facets once here in generateOverview and reuse for both topic-level
+  // filtering metadata (#73) and the synthesis loop below.
   const facetsMap = synthesisConfig.facetsDir
     ? readFacetsDir(synthesisConfig.facetsDir)
     : undefined;
 
   // Attach a compact facets summary to each topic so the UI can filter by goal
   // category without recomputing the aggregation (issue #73).
-  if (facetsMap && facetsMap.size > 0) {
-    for (const node of knowledgeGraph.nodes) {
-      const summary = buildTopicFacetsSummary(
-        aggregateFacetsForTopic(node.sessionIds, facetsMap)
-      );
-      if (summary) node.facetsSummary = summary;
-    }
-  }
+  attachFacetsSummaries(knowledgeGraph.nodes, facetsMap);
 
   // Top files
   const topFiles = [...fileEditCounts.entries()]
@@ -638,8 +631,7 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
     if (total > 0) {
       console.error(`[crune] Synthesizing top ${total} skill candidates${synthesisConfig.model ? ` (model: ${synthesisConfig.model})` : ""}...`);
     }
-    // Reuse the facets read above (loop-invariant) for synthesis enrichment.
-    const facetsForSynthesis = facetsMap;
+    // facetsMap was read once above (loop-invariant) — reuse it directly.
     for (let i = 0; i < topCandidates.length; i++) {
       const candidate = topCandidates[i];
       const topic = knowledgeGraph.nodes.find((n) => n.id === candidate.topicId);
@@ -653,8 +645,8 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
       console.error(`[crune]   [${i + 1}/${total}] ${topic.label}...`);
 
       // Build facets insights for this topic if facets data is available
-      const facetsInsights = facetsForSynthesis
-        ? aggregateFacetsForTopic(topic.sessionIds, facetsForSynthesis)
+      const facetsInsights = facetsMap
+        ? aggregateFacetsForTopic(topic.sessionIds, facetsMap)
         : undefined;
 
       // Human-flagged moments for this topic (issue #24), only when enabled.

--- a/scripts/analyze-sessions.ts
+++ b/scripts/analyze-sessions.ts
@@ -15,6 +15,7 @@ import {
   buildSemanticKnowledgeGraph,
   readFacetsDir,
   aggregateFacetsForTopic,
+  buildTopicFacetsSummary,
   type SessionInput,
   type SemanticKnowledgeGraph,
   embedSessions,
@@ -525,6 +526,23 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
     humanSignalMap: synthesisConfig.useHumanFeedback ? humanSignalMap : undefined,
   });
 
+  // Read facets once and reuse for both topic-level filtering metadata (#73)
+  // and the synthesis loop below.
+  const facetsMap = synthesisConfig.facetsDir
+    ? readFacetsDir(synthesisConfig.facetsDir)
+    : undefined;
+
+  // Attach a compact facets summary to each topic so the UI can filter by goal
+  // category without recomputing the aggregation (issue #73).
+  if (facetsMap && facetsMap.size > 0) {
+    for (const node of knowledgeGraph.nodes) {
+      const summary = buildTopicFacetsSummary(
+        aggregateFacetsForTopic(node.sessionIds, facetsMap)
+      );
+      if (summary) node.facetsSummary = summary;
+    }
+  }
+
   // Top files
   const topFiles = [...fileEditCounts.entries()]
     .sort((a, b) => b[1] - a[1])
@@ -620,11 +638,8 @@ async function generateOverview(sessions: ParsedSession[], synthesisConfig: Synt
     if (total > 0) {
       console.error(`[crune] Synthesizing top ${total} skill candidates${synthesisConfig.model ? ` (model: ${synthesisConfig.model})` : ""}...`);
     }
-    // Read facets once for the whole loop — the result is loop-invariant, so
-    // re-reading/re-parsing the directory per candidate was wasted I/O.
-    const facetsForSynthesis = synthesisConfig.facetsDir
-      ? readFacetsDir(synthesisConfig.facetsDir)
-      : undefined;
+    // Reuse the facets read above (loop-invariant) for synthesis enrichment.
+    const facetsForSynthesis = facetsMap;
     for (let i = 0; i < topCandidates.length; i++) {
       const candidate = topCandidates[i];
       const topic = knowledgeGraph.nodes.find((n) => n.id === candidate.topicId);

--- a/scripts/knowledge-graph-builder.ts
+++ b/scripts/knowledge-graph-builder.ts
@@ -69,6 +69,7 @@ export {
   helpfulnessToScore,
   aggregateFacetsForTopic,
   buildTopicFacetsSummary,
+  attachFacetsSummaries,
   // RAG embedding pipeline + retriever (issue #32)
   extractChunks,
   embedSessions,

--- a/scripts/knowledge-graph-builder.ts
+++ b/scripts/knowledge-graph-builder.ts
@@ -63,6 +63,7 @@ export {
   // Facets
   type FacetsData,
   type FacetsInsightsSummary,
+  type TopicFacetsSummary,
   readFacetsDir,
   normalizeGoalCategory,
   helpfulnessToScore,

--- a/scripts/knowledge-graph-builder.ts
+++ b/scripts/knowledge-graph-builder.ts
@@ -67,6 +67,7 @@ export {
   normalizeGoalCategory,
   helpfulnessToScore,
   aggregateFacetsForTopic,
+  buildTopicFacetsSummary,
   // RAG embedding pipeline + retriever (issue #32)
   extractChunks,
   embedSessions,

--- a/scripts/knowledge-graph/facets-reader.ts
+++ b/scripts/knowledge-graph/facets-reader.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import type { FacetsData, FacetsInsightsSummary } from "./types.js";
+import type { FacetsData, FacetsInsightsSummary, TopicFacetsSummary } from "./types.js";
 
 // ─── Goal category normalization ────────────────────────────────────────────
 
@@ -216,5 +216,25 @@ export function aggregateFacetsForTopic(
     helpfulnessScore,
     commonFrictions,
     frictionDetails,
+  };
+}
+
+/**
+ * Map an aggregated facets summary to the compact per-topic shape persisted on
+ * a TopicNode for UI filtering (issue #73). Returns undefined when there is no
+ * category/goal signal (so the field stays absent rather than empty).
+ */
+export function buildTopicFacetsSummary(
+  agg: FacetsInsightsSummary | undefined
+): TopicFacetsSummary | undefined {
+  if (!agg) return undefined;
+  if (agg.normalizedCategories.length === 0 && agg.aggregatedGoals.length === 0) {
+    return undefined;
+  }
+  return {
+    categories: agg.normalizedCategories,
+    goals: agg.aggregatedGoals,
+    successRate: agg.successRate,
+    helpfulness: agg.helpfulnessScore,
   };
 }

--- a/scripts/knowledge-graph/facets-reader.ts
+++ b/scripts/knowledge-graph/facets-reader.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import type { FacetsData, FacetsInsightsSummary, TopicFacetsSummary } from "./types.js";
+import type { FacetsData, FacetsInsightsSummary, TopicFacetsSummary, TopicNode } from "./types.js";
 
 // ─── Goal category normalization ────────────────────────────────────────────
 
@@ -237,4 +237,22 @@ export function buildTopicFacetsSummary(
     successRate: agg.successRate,
     helpfulness: agg.helpfulnessScore,
   };
+}
+
+/**
+ * Attach a {@link TopicFacetsSummary} to every topic that has facets signal
+ * (issue #73). No-op when no facets data is available. Mutates the nodes in
+ * place; extracted from analyze-sessions so the attachment is unit-testable.
+ */
+export function attachFacetsSummaries(
+  nodes: TopicNode[],
+  facetsMap: Map<string, FacetsData> | undefined
+): void {
+  if (!facetsMap || facetsMap.size === 0) return;
+  for (const node of nodes) {
+    const summary = buildTopicFacetsSummary(
+      aggregateFacetsForTopic(node.sessionIds, facetsMap)
+    );
+    if (summary) node.facetsSummary = summary;
+  }
 }

--- a/scripts/knowledge-graph/index.ts
+++ b/scripts/knowledge-graph/index.ts
@@ -84,7 +84,7 @@ export { computeReusabilityScores, computeSessionHumanSignal, aggregateHumanSign
 export type { SessionHumanSignal } from "./reusability.js";
 export { abstractToolCall, extractEnrichedSequences } from "./tool-pattern.js";
 export { generateSkillMarkdown, generateHookJson, generateSkillCandidates } from "./skill-generator.js";
-export { readFacetsDir, normalizeGoalCategory, helpfulnessToScore, aggregateFacetsForTopic, buildTopicFacetsSummary } from "./facets-reader.js";
+export { readFacetsDir, normalizeGoalCategory, helpfulnessToScore, aggregateFacetsForTopic, buildTopicFacetsSummary, attachFacetsSummaries } from "./facets-reader.js";
 
 // ─── RAG embedding pipeline + retriever (issue #32) ──────────────────────────
 export {

--- a/scripts/knowledge-graph/index.ts
+++ b/scripts/knowledge-graph/index.ts
@@ -83,7 +83,7 @@ export { computeReusabilityScores, computeSessionHumanSignal, aggregateHumanSign
 export type { SessionHumanSignal } from "./reusability.js";
 export { abstractToolCall, extractEnrichedSequences } from "./tool-pattern.js";
 export { generateSkillMarkdown, generateHookJson, generateSkillCandidates } from "./skill-generator.js";
-export { readFacetsDir, normalizeGoalCategory, helpfulnessToScore, aggregateFacetsForTopic } from "./facets-reader.js";
+export { readFacetsDir, normalizeGoalCategory, helpfulnessToScore, aggregateFacetsForTopic, buildTopicFacetsSummary } from "./facets-reader.js";
 
 // ─── RAG embedding pipeline + retriever (issue #32) ──────────────────────────
 export {

--- a/scripts/knowledge-graph/index.ts
+++ b/scripts/knowledge-graph/index.ts
@@ -50,6 +50,7 @@ export type {
   SkillCandidate,
   FacetsData,
   FacetsInsightsSummary,
+  TopicFacetsSummary,
 } from "./types.js";
 
 export { tokenize, splitCamelCase, extractPathTokens, isNoiseToken } from "./tokenizer.js";

--- a/scripts/knowledge-graph/types.ts
+++ b/scripts/knowledge-graph/types.ts
@@ -96,6 +96,23 @@ export interface TopicNode {
   toolSignature: { tool: string; weight: number }[];
   dominantRole: "user-driven" | "tool-heavy" | "subagent-delegated";
   reusabilityScore: ReusabilityScore;
+  /** Compact /insights facets summary for UI filtering (issue #73). Present only
+   *  when facets data was available at build time. */
+  facetsSummary?: TopicFacetsSummary;
+}
+
+/**
+ * Compact per-topic facets summary persisted onto {@link TopicNode} so the UI
+ * can filter topics by goal category without recomputing the aggregation
+ * (issue #73). A serializable subset of {@link FacetsInsightsSummary}.
+ */
+export interface TopicFacetsSummary {
+  /** Normalized goal categories (feature / bugfix / refactoring / …). */
+  categories: string[];
+  /** Raw underlying-goal phrases (a few, de-duplicated). */
+  goals: string[];
+  successRate?: number;
+  helpfulness?: number;
 }
 
 export interface TopicEdge {

--- a/scripts/knowledge-graph/types.ts
+++ b/scripts/knowledge-graph/types.ts
@@ -111,8 +111,9 @@ export interface TopicFacetsSummary {
   categories: string[];
   /** Raw underlying-goal phrases (a few, de-duplicated). */
   goals: string[];
-  successRate?: number;
-  helpfulness?: number;
+  /** Always set when a summary exists (the aggregation always computes them). */
+  successRate: number;
+  helpfulness: number;
 }
 
 export interface TopicEdge {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -186,8 +186,8 @@ export interface TopicNode {
 export interface TopicFacetsSummary {
   categories: string[] // normalized goal categories (feature / bugfix / refactoring / …)
   goals: string[] // raw underlying-goal phrases (a few, de-duplicated)
-  successRate?: number
-  helpfulness?: number
+  successRate: number // always set when a summary exists
+  helpfulness: number
 }
 
 export interface TopicEdge {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -176,6 +176,18 @@ export interface TopicNode {
   toolSignature: { tool: string; weight: number }[] // top tools by Tool-IDF weight
   dominantRole: 'user-driven' | 'tool-heavy' | 'subagent-delegated'
   reusabilityScore: ReusabilityScore
+  facetsSummary?: TopicFacetsSummary // /insights facets summary for filtering (#73), when available
+}
+
+/**
+ * Compact per-topic facets summary for UI filtering (issue #73).
+ * Present only when /insights facets data was available at build time.
+ */
+export interface TopicFacetsSummary {
+  categories: string[] // normalized goal categories (feature / bugfix / refactoring / …)
+  goals: string[] // raw underlying-goal phrases (a few, de-duplicated)
+  successRate?: number
+  helpfulness?: number
 }
 
 export interface TopicEdge {


### PR DESCRIPTION
First slice of #73 (filter-driven skill explorer). Data layer only: makes /insights goal categories available per-topic so the upcoming explorer can filter by them without recomputation.

## What
- New serializable `TopicFacetsSummary` (`categories` / `goals` / `successRate` / `helpfulness`) on `TopicNode` (mirrored in `src/types` and `scripts` types, like the rest of `TopicNode`).
- Pure `buildTopicFacetsSummary(agg)` mapper (returns `undefined` when there's no category/goal signal, so the field stays absent rather than empty).
- `attachFacetsSummaries(nodes, facetsMap)` attaches it to every topic with facets signal; called in `generateOverview`. Facets are read once there and reused for the synthesis loop (was read twice).

## Review (/nirami + /code-review) — fixes, one commit each
- `successRate` / `helpfulness` made **required** (the mapper always sets them; optional expressed an impossible state). *(forest)*
- Re-export the `TopicFacetsSummary` **type** from the barrels (the function was exported but not the type). *(code-review)*
- Extract `attachFacetsSummaries` to a pure, **unit-tested** helper (facets-hit / no-facets-node / absent-empty-map); drop a redundant `facetsForSynthesis = facetsMap` alias; pin the AND empty-signal semantics with one-side-empty tests. *(stone / river)*

## Deliberately deferred (noted, out of this PR's scope)
- `TopicFacetsSummary` is hand-mirrored across `src`/`scripts` — consistent with how the **whole** `TopicNode` is already mirrored; unifying just this field would be inconsistent. Follow-up if we ever share `TopicNode` itself.
- The facets directory is still read in 3 places (`buildSemanticKnowledgeGraph` internal, `generateOverview`, `generateIndex`) — pre-existing; a full hoist (pass a `Map` instead of a dir) is a separate refactor.
- `readFacetsDir` uses `as` casts rather than zod validation at the boundary — pre-existing.

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ 697/697.

Next: PR B (the explorer UI) consumes `TopicNode.facetsSummary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)