### PR TITLE
feat(#73): filter-driven skill explorer (Wave 6 MVP)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { SessionDashboardView } from './components/overview/SessionDashboardView
 import { SessionPlayback } from './components/playback/SessionPlayback'
 import { HelpModal } from './components/HelpModal'
 import './App.css'
-import { KnowledgeGraphView } from './components/knowledge/KnowledgeGraphView'
+import { KnowledgeView } from './components/knowledge/KnowledgeView'
 import { useSessionOverview } from './hooks/useSessionOverview'
 
 type ViewMode = 'overview' | 'knowledge'
@@ -83,7 +83,7 @@ function App() {
           </>
         )}
         {activeTab === 'knowledge' && (
-          <KnowledgeGraphView
+          <KnowledgeView
             overview={overviewData}
             loading={overviewLoading}
             error={overviewError}

--- a/src/components/knowledge/ExplorerSkillCard.css
+++ b/src/components/knowledge/ExplorerSkillCard.css
@@ -1,0 +1,272 @@
+.fse-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fse-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.fse-card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.fse-card-score {
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.fse-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.fse-card-role {
+  font-weight: 600;
+}
+
+.fse-card-project {
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.fse-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.fse-card-tag {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.fse-card-skill {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fse-card-toggle,
+.fse-card-synth,
+.fse-card-copy,
+.fse-card-session {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.fse-card-toggle {
+  align-self: flex-start;
+  font-size: 11px;
+  padding: 3px 8px;
+  color: var(--text-secondary);
+  border-color: transparent;
+}
+
+.fse-card-md-pre {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  line-height: 1.5;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.fse-card-copy {
+  margin-top: 6px;
+  font-size: 11px;
+  padding: 3px 8px;
+}
+
+.fse-card-nosynth {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.fse-card-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.fse-card-synth {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 12px;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.fse-card-synth:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.fse-card-error {
+  margin: 0;
+  font-size: 11px;
+  color: var(--danger);
+}
+
+.fse-card-related summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.fse-card-session-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.fse-card-session {
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  padding: 2px 6px;
+  color: var(--text-secondary);
+}
+
+.fse-card-session:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* SkillEvaluationBadge host styles (prefix="fse") */
+.fse-eval {
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: var(--bg-tertiary);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fse-eval--pass {
+  border-left-color: var(--success);
+}
+
+.fse-eval--borderline {
+  border-left-color: var(--warning);
+}
+
+.fse-eval--fail {
+  border-left-color: var(--danger);
+}
+
+.fse-eval-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fse-eval-chip {
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.fse-eval-chip--ok {
+  color: var(--success);
+  background-color: rgba(22, 163, 74, 0.1);
+}
+
+.fse-eval-chip--ng {
+  color: var(--danger);
+  background-color: rgba(220, 38, 38, 0.1);
+}
+
+.fse-eval-score {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.fse-eval-issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fse-eval-issue {
+  font-size: 11px;
+  color: var(--danger);
+}
+
+.fse-eval-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.fse-eval-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fse-eval-hints-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.fse-eval-hints-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fse-eval-hint {
+  font-size: 11px;
+  color: var(--text-primary);
+  line-height: 1.4;
+}

--- a/src/components/knowledge/ExplorerSkillCard.tsx
+++ b/src/components/knowledge/ExplorerSkillCard.tsx
@@ -9,6 +9,8 @@ import type {
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import { SkillEvaluationBadge } from './SkillEvaluationBadge'
+import { SkillCopyButton } from './SkillCopyButton'
+import { ROLE_LABELS } from './skillExplorerFilter'
 import './ExplorerSkillCard.css'
 
 interface Props {
@@ -20,24 +22,6 @@ interface Props {
   communities: KnowledgeCommunity[]
   bridgeTopicIds: string[]
   onSessionSelect: (sessionId: string) => void
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-  const onCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      /* clipboard unavailable — ignore */
-    }
-  }, [text])
-  return (
-    <button className="fse-card-copy" onClick={onCopy}>
-      {copied ? 'コピーしました' : 'Skillをコピー'}
-    </button>
-  )
 }
 
 export function ExplorerSkillCard({
@@ -81,7 +65,7 @@ export function ExplorerSkillCard({
       </header>
 
       <div className="fse-card-meta">
-        <span className="fse-card-role">{topic.dominantRole}</span>
+        <span className="fse-card-role">{ROLE_LABELS[topic.dominantRole]}</span>
         <span className="fse-card-sessions">{topic.sessionCount} sessions</span>
         {topic.projects.slice(0, 2).map((p) => (
           <span key={p} className="fse-card-project">{p}</span>
@@ -112,7 +96,7 @@ export function ExplorerSkillCard({
           {expanded && (
             <div className="fse-card-md">
               <pre className="fse-card-md-pre">{markdown}</pre>
-              <CopyButton text={markdown} />
+              <SkillCopyButton text={markdown} className="fse-card-copy" />
             </div>
           )}
         </div>

--- a/src/components/knowledge/ExplorerSkillCard.tsx
+++ b/src/components/knowledge/ExplorerSkillCard.tsx
@@ -1,0 +1,148 @@
+import { useState, useCallback } from 'react'
+import type {
+  TopicNode,
+  TopicEdge,
+  KnowledgeCommunity,
+  SkillCandidate,
+  EnrichedToolSequence,
+} from '../../types'
+import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
+import { buildGraphContext } from '../../utils/buildGraphContext'
+import { SkillEvaluationBadge } from './SkillEvaluationBadge'
+import './ExplorerSkillCard.css'
+
+interface Props {
+  topic: TopicNode
+  candidate?: SkillCandidate
+  enrichedSequences: EnrichedToolSequence[]
+  allTopics: TopicNode[]
+  edges: TopicEdge[]
+  communities: KnowledgeCommunity[]
+  bridgeTopicIds: string[]
+  onSessionSelect: (sessionId: string) => void
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* clipboard unavailable — ignore */
+    }
+  }, [text])
+  return (
+    <button className="fse-card-copy" onClick={onCopy}>
+      {copied ? 'コピーしました' : 'Skillをコピー'}
+    </button>
+  )
+}
+
+export function ExplorerSkillCard({
+  topic,
+  candidate,
+  enrichedSequences,
+  allTopics,
+  edges,
+  communities,
+  bridgeTopicIds,
+  onSessionSelect,
+}: Props) {
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis()
+  const [expanded, setExpanded] = useState(false)
+
+  const score = Math.round((topic.reusabilityScore?.overall ?? 0) * 100)
+  const markdown = result ?? candidate?.synthesizedMarkdown ?? null
+
+  const onSynthesize = useCallback(() => {
+    if (!candidate) return
+    reset()
+    const relatedSequences = enrichedSequences.filter((seq) =>
+      seq.sessionIds.some((sid) => topic.sessionIds.includes(sid)),
+    )
+    const topicEdges = edges.filter((e) => e.source === topic.id || e.target === topic.id)
+    synthesize({
+      skillCandidate: candidate,
+      topicNode: topic,
+      enrichedSequences: relatedSequences,
+      graphContext: buildGraphContext(topic, topicEdges, allTopics, communities, bridgeTopicIds),
+    })
+  }, [candidate, enrichedSequences, edges, topic, allTopics, communities, bridgeTopicIds, synthesize, reset])
+
+  return (
+    <article className="fse-card">
+      <header className="fse-card-head">
+        <h3 className="fse-card-title">{topic.label}</h3>
+        <span className="fse-card-score" title="Reusability score">
+          {score}%
+        </span>
+      </header>
+
+      <div className="fse-card-meta">
+        <span className="fse-card-role">{topic.dominantRole}</span>
+        <span className="fse-card-sessions">{topic.sessionCount} sessions</span>
+        {topic.projects.slice(0, 2).map((p) => (
+          <span key={p} className="fse-card-project">{p}</span>
+        ))}
+      </div>
+
+      {topic.facetsSummary && topic.facetsSummary.categories.length > 0 && (
+        <div className="fse-card-tags">
+          {topic.facetsSummary.categories.map((c) => (
+            <span key={c} className="fse-card-tag">{c}</span>
+          ))}
+        </div>
+      )}
+
+      {candidate?.evaluation && (
+        <SkillEvaluationBadge evaluation={candidate.evaluation} prefix="fse" />
+      )}
+
+      {markdown ? (
+        <div className="fse-card-skill">
+          <button
+            className="fse-card-toggle"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? '▼ 合成Skillを隠す' : '▶ 合成Skillを表示'}
+          </button>
+          {expanded && (
+            <div className="fse-card-md">
+              <pre className="fse-card-md-pre">{markdown}</pre>
+              <CopyButton text={markdown} />
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="fse-card-nosynth">未合成（再合成で生成）</p>
+      )}
+
+      <div className="fse-card-actions">
+        {candidate && (
+          <button className="fse-card-synth" disabled={loading} onClick={onSynthesize}>
+            {loading ? '合成中...' : markdown ? '再合成' : '合成'}
+          </button>
+        )}
+      </div>
+      {error && <p className="fse-card-error">{error}</p>}
+
+      {topic.sessionIds.length > 0 && (
+        <details className="fse-card-related">
+          <summary>関連セッション ({topic.sessionIds.length})</summary>
+          <ul className="fse-card-session-list">
+            {topic.sessionIds.slice(0, 8).map((sid) => (
+              <li key={sid}>
+                <button className="fse-card-session" onClick={() => onSessionSelect(sid)}>
+                  {sid.slice(0, 8)}…
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </article>
+  )
+}

--- a/src/components/knowledge/KnowledgeView.css
+++ b/src/components/knowledge/KnowledgeView.css
@@ -1,0 +1,37 @@
+.kv-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.kv-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.kv-toggle-btn {
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  padding: 6px 14px;
+}
+
+.kv-toggle-btn--on {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.kv-body {
+  flex: 1;
+  min-height: 0;
+}

--- a/src/components/knowledge/KnowledgeView.tsx
+++ b/src/components/knowledge/KnowledgeView.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import type { SessionOverviewData } from '../../types'
+import { KnowledgeGraphView } from './KnowledgeGraphView'
+import { SkillExplorerView } from './SkillExplorerView'
+import './KnowledgeView.css'
+
+type Mode = 'explorer' | 'graph'
+
+interface Props {
+  overview: SessionOverviewData | null
+  loading: boolean
+  error: string | null
+  onSessionSelect: (sessionId: string) => void
+}
+
+/**
+ * Container for the knowledge tab. Defaults to the filter-driven skill explorer
+ * (issue #73); the force-directed graph is kept behind a toggle.
+ */
+export function KnowledgeView(props: Props) {
+  const [mode, setMode] = useState<Mode>('explorer')
+
+  return (
+    <div className="kv-root">
+      <div className="kv-toggle" role="tablist" aria-label="Knowledge view mode">
+        <button
+          role="tab"
+          aria-selected={mode === 'explorer'}
+          className={`kv-toggle-btn${mode === 'explorer' ? ' kv-toggle-btn--on' : ''}`}
+          onClick={() => setMode('explorer')}
+        >
+          Skillエクスプローラ
+        </button>
+        <button
+          role="tab"
+          aria-selected={mode === 'graph'}
+          className={`kv-toggle-btn${mode === 'graph' ? ' kv-toggle-btn--on' : ''}`}
+          onClick={() => setMode('graph')}
+        >
+          グラフ
+        </button>
+      </div>
+      <div className="kv-body">
+        {mode === 'explorer' ? (
+          <SkillExplorerView {...props} />
+        ) : (
+          <KnowledgeGraphView {...props} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/knowledge/SkillCopyButton.tsx
+++ b/src/components/knowledge/SkillCopyButton.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Copy a synthesized skill to the clipboard, falling back to a file download
+ * when the Clipboard API is unavailable (non-secure context / denied). Shared by
+ * the knowledge views so the copy behaviour is consistent.
+ */
+export function SkillCopyButton({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      if (timer.current) clearTimeout(timer.current)
+      timer.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable — download the skill so the action never silently
+      // no-ops.
+      const url = URL.createObjectURL(new Blob([text], { type: 'text/markdown' }))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'SKILL.md'
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+  }, [text])
+
+  return (
+    <button className={className} onClick={onCopy}>
+      {copied ? 'コピーしました' : 'Skillをコピー'}
+    </button>
+  )
+}

--- a/src/components/knowledge/SkillExplorerView.css
+++ b/src/components/knowledge/SkillExplorerView.css
@@ -1,0 +1,135 @@
+.fse-root {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 16px;
+  height: 100%;
+  overflow: hidden;
+}
+
+.fse-filters {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+}
+
+.fse-filters-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fse-filters-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.fse-reset {
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--accent);
+}
+
+.fse-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fse-filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.fse-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.fse-chip {
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2px 9px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.fse-chip--on {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.fse-search {
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.fse-results {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fse-results-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  background: var(--bg-primary);
+  padding-bottom: 4px;
+}
+
+.fse-results-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.fse-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.fse-state {
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.fse-state--error {
+  color: var(--danger);
+}
+
+@media (max-width: 720px) {
+  .fse-root {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/knowledge/SkillExplorerView.tsx
+++ b/src/components/knowledge/SkillExplorerView.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useState } from 'react'
+import type { SessionOverviewData } from '../../types'
+import {
+  EMPTY_CRITERIA,
+  collectFilterOptions,
+  filterTopics,
+  isEmptyCriteria,
+  type TopicFilterCriteria,
+  type DominantRole,
+} from './skillExplorerFilter'
+import { ExplorerSkillCard } from './ExplorerSkillCard'
+import './SkillExplorerView.css'
+
+interface Props {
+  overview: SessionOverviewData | null
+  loading: boolean
+  error: string | null
+  onSessionSelect: (sessionId: string) => void
+}
+
+const ROLE_LABELS: Record<DominantRole, string> = {
+  'user-driven': 'ユーザー主導',
+  'tool-heavy': 'ツール多用',
+  'subagent-delegated': 'サブエージェント委譲',
+}
+
+const SINCE_OPTIONS: { label: string; days: number | null }[] = [
+  { label: '全期間', days: null },
+  { label: '直近30日', days: 30 },
+  { label: '直近90日', days: 90 },
+]
+
+function ChipGroup<T extends string | number>({
+  label,
+  options,
+  selected,
+  render,
+  onToggle,
+}: {
+  label: string
+  options: T[]
+  selected: T[]
+  render?: (v: T) => string
+  onToggle: (v: T) => void
+}) {
+  if (options.length === 0) return null
+  return (
+    <div className="fse-filter-group">
+      <span className="fse-filter-label">{label}</span>
+      <div className="fse-filter-chips">
+        {options.map((o) => (
+          <button
+            key={String(o)}
+            className={`fse-chip${selected.includes(o) ? ' fse-chip--on' : ''}`}
+            onClick={() => onToggle(o)}
+          >
+            {render ? render(o) : String(o)}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function SkillExplorerView({ overview, loading, error, onSessionSelect }: Props) {
+  const [criteria, setCriteria] = useState<TopicFilterCriteria>(EMPTY_CRITERIA)
+
+  const graph = overview?.knowledgeGraph
+  const nodes = useMemo(() => graph?.nodes ?? [], [graph])
+  const candidates = useMemo(() => overview?.tacitKnowledge?.skillCandidates ?? [], [overview])
+
+  const options = useMemo(() => collectFilterOptions(nodes), [nodes])
+
+  const candidateByTopic = useMemo(
+    () => new Map(candidates.map((c) => [c.topicId, c])),
+    [candidates],
+  )
+  const evalScores = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const c of candidates) {
+      if (c.evaluation?.overallScore !== undefined) m.set(c.topicId, c.evaluation.overallScore)
+    }
+    return m
+  }, [candidates])
+
+  const filtered = useMemo(() => {
+    const result = filterTopics(nodes, criteria, evalScores)
+    return result.sort((a, b) => (b.reusabilityScore?.overall ?? 0) - (a.reusabilityScore?.overall ?? 0))
+  }, [nodes, criteria, evalScores])
+
+  const toggle = <K extends 'projects' | 'categories' | 'communities' | 'roles'>(
+    key: K,
+    value: TopicFilterCriteria[K][number],
+  ) => {
+    setCriteria((c) => {
+      const arr = c[key] as TopicFilterCriteria[K][number][]
+      const next = arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value]
+      return { ...c, [key]: next }
+    })
+  }
+
+  const setSince = (days: number | null) => {
+    if (days === null) return setCriteria((c) => ({ ...c, since: null }))
+    const d = new Date()
+    d.setDate(d.getDate() - days)
+    setCriteria((c) => ({ ...c, since: d.toISOString() }))
+  }
+
+  if (loading) return <div className="fse-state">読み込み中…</div>
+  if (error) return <div className="fse-state fse-state--error">{error}</div>
+  if (!graph) return <div className="fse-state">データがありません</div>
+
+  return (
+    <div className="fse-root">
+      <aside className="fse-filters">
+        <div className="fse-filters-head">
+          <h2 className="fse-filters-title">フィルタ</h2>
+          {!isEmptyCriteria(criteria) && (
+            <button className="fse-reset" onClick={() => setCriteria(EMPTY_CRITERIA)}>
+              リセット
+            </button>
+          )}
+        </div>
+
+        <div className="fse-filter-group">
+          <span className="fse-filter-label">キーワード</span>
+          <input
+            className="fse-search"
+            type="search"
+            placeholder="ラベル・キーワード"
+            value={criteria.keyword}
+            onChange={(e) => setCriteria((c) => ({ ...c, keyword: e.target.value }))}
+          />
+        </div>
+
+        <ChipGroup label="プロジェクト" options={options.projects} selected={criteria.projects} onToggle={(v) => toggle('projects', v)} />
+        <ChipGroup label="目標カテゴリ" options={options.categories} selected={criteria.categories} onToggle={(v) => toggle('categories', v)} />
+        <ChipGroup label="役割" options={options.roles} selected={criteria.roles} render={(r) => ROLE_LABELS[r]} onToggle={(v) => toggle('roles', v)} />
+        <ChipGroup label="コミュニティ" options={options.communities} selected={criteria.communities} render={(c) => `#${c}`} onToggle={(v) => toggle('communities', v)} />
+
+        <div className="fse-filter-group">
+          <span className="fse-filter-label">再利用性スコア ≥ {Math.round(criteria.minReusability * 100)}%</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={Math.round(criteria.minReusability * 100)}
+            onChange={(e) => setCriteria((c) => ({ ...c, minReusability: Number(e.target.value) / 100 }))}
+          />
+        </div>
+
+        <div className="fse-filter-group">
+          <span className="fse-filter-label">評価スコア ≥ {criteria.minEvalScore}</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={criteria.minEvalScore}
+            onChange={(e) => setCriteria((c) => ({ ...c, minEvalScore: Number(e.target.value) }))}
+          />
+        </div>
+
+        <div className="fse-filter-group">
+          <span className="fse-filter-label">期間</span>
+          <div className="fse-filter-chips">
+            {SINCE_OPTIONS.map((o) => {
+              const active = o.days === null ? criteria.since === null : criteria.since !== null
+              return (
+                <button
+                  key={o.label}
+                  className={`fse-chip${active && (o.days !== null || criteria.since === null) ? ' fse-chip--on' : ''}`}
+                  onClick={() => setSince(o.days)}
+                >
+                  {o.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </aside>
+
+      <section className="fse-results">
+        <div className="fse-results-head">
+          <span className="fse-results-count">
+            {filtered.length} / {nodes.length} トピック
+          </span>
+        </div>
+        {filtered.length === 0 ? (
+          <div className="fse-state">条件に一致するトピックがありません</div>
+        ) : (
+          <div className="fse-grid">
+            {filtered.map((topic) => (
+              <ExplorerSkillCard
+                key={topic.id}
+                topic={topic}
+                candidate={candidateByTopic.get(topic.id)}
+                enrichedSequences={overview?.tacitKnowledge?.enrichedToolSequences ?? []}
+                allTopics={nodes}
+                edges={graph.edges}
+                communities={graph.communities}
+                bridgeTopicIds={graph.metrics?.bridgeTopicIds ?? []}
+                onSessionSelect={onSessionSelect}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/knowledge/SkillExplorerView.tsx
+++ b/src/components/knowledge/SkillExplorerView.tsx
@@ -2,11 +2,12 @@ import { useMemo, useState } from 'react'
 import type { SessionOverviewData } from '../../types'
 import {
   EMPTY_CRITERIA,
+  ROLE_LABELS,
   collectFilterOptions,
   filterTopics,
+  sortByReusability,
   isEmptyCriteria,
   type TopicFilterCriteria,
-  type DominantRole,
 } from './skillExplorerFilter'
 import { ExplorerSkillCard } from './ExplorerSkillCard'
 import './SkillExplorerView.css'
@@ -18,11 +19,8 @@ interface Props {
   onSessionSelect: (sessionId: string) => void
 }
 
-const ROLE_LABELS: Record<DominantRole, string> = {
-  'user-driven': 'ユーザー主導',
-  'tool-heavy': 'ツール多用',
-  'subagent-delegated': 'サブエージェント委譲',
-}
+/** Keys of TopicFilterCriteria whose value is an array (the multi-select axes). */
+type ArrayKeys<T> = { [K in keyof T]: T[K] extends unknown[] ? K : never }[keyof T]
 
 const SINCE_OPTIONS: { label: string; days: number | null }[] = [
   { label: '全期間', days: null },
@@ -83,27 +81,22 @@ export function SkillExplorerView({ overview, loading, error, onSessionSelect }:
     return m
   }, [candidates])
 
-  const filtered = useMemo(() => {
-    const result = filterTopics(nodes, criteria, evalScores)
-    return result.sort((a, b) => (b.reusabilityScore?.overall ?? 0) - (a.reusabilityScore?.overall ?? 0))
-  }, [nodes, criteria, evalScores])
+  const filtered = useMemo(
+    () => sortByReusability(filterTopics(nodes, criteria, evalScores)),
+    [nodes, criteria, evalScores],
+  )
 
-  const toggle = <K extends 'projects' | 'categories' | 'communities' | 'roles'>(
+  const toggle = <K extends ArrayKeys<TopicFilterCriteria>>(
     key: K,
     value: TopicFilterCriteria[K][number],
   ) => {
     setCriteria((c) => {
+      // Cast: TS can't narrow a generic union of array-valued props to one
+      // element type, but ArrayKeys already guarantees `key` is an array axis.
       const arr = c[key] as TopicFilterCriteria[K][number][]
       const next = arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value]
       return { ...c, [key]: next }
     })
-  }
-
-  const setSince = (days: number | null) => {
-    if (days === null) return setCriteria((c) => ({ ...c, since: null }))
-    const d = new Date()
-    d.setDate(d.getDate() - days)
-    setCriteria((c) => ({ ...c, since: d.toISOString() }))
   }
 
   if (loading) return <div className="fse-state">読み込み中…</div>
@@ -163,18 +156,15 @@ export function SkillExplorerView({ overview, loading, error, onSessionSelect }:
         <div className="fse-filter-group">
           <span className="fse-filter-label">期間</span>
           <div className="fse-filter-chips">
-            {SINCE_OPTIONS.map((o) => {
-              const active = o.days === null ? criteria.since === null : criteria.since !== null
-              return (
-                <button
-                  key={o.label}
-                  className={`fse-chip${active && (o.days !== null || criteria.since === null) ? ' fse-chip--on' : ''}`}
-                  onClick={() => setSince(o.days)}
-                >
-                  {o.label}
-                </button>
-              )
-            })}
+            {SINCE_OPTIONS.map((o) => (
+              <button
+                key={o.label}
+                className={`fse-chip${o.days === criteria.sinceDays ? ' fse-chip--on' : ''}`}
+                onClick={() => setCriteria((c) => ({ ...c, sinceDays: o.days }))}
+              >
+                {o.label}
+              </button>
+            ))}
           </div>
         </div>
       </aside>

--- a/src/components/knowledge/TacitKnowledgeView.tsx
+++ b/src/components/knowledge/TacitKnowledgeView.tsx
@@ -1,8 +1,8 @@
-import { useState, useCallback } from 'react'
 import type { KnowledgeGraphMetrics, TopicNode, TopicEdge, KnowledgeCommunity, TacitKnowledge, SkillCandidate, EnrichedToolSequence } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import { SkillEvaluationBadge } from './SkillEvaluationBadge'
+import { SkillCopyButton } from './SkillCopyButton'
 import './TacitKnowledgeView.css'
 
 interface Props {
@@ -11,32 +11,6 @@ interface Props {
   topics?: TopicNode[]
   edges?: TopicEdge[]
   communities?: KnowledgeCommunity[]
-}
-
-function CopyButton({ text, label }: { text: string; label: string }) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      const blob = new Blob([text], { type: 'text/plain' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = 'skill.md'
-      a.click()
-      URL.revokeObjectURL(url)
-    }
-  }, [text])
-
-  return (
-    <button className="tk-export-btn" onClick={handleCopy}>
-      {copied ? 'Copied!' : label}
-    </button>
-  )
 }
 
 function DistillButton({
@@ -75,7 +49,7 @@ function DistillButton({
       {candidate.synthesizedMarkdown && !result && (
         <div className="tk-synth-result">
           <div className="tk-synth-preview">{candidate.synthesizedMarkdown}</div>
-          <CopyButton text={candidate.synthesizedMarkdown} label="Copy Skill" />
+          <SkillCopyButton text={candidate.synthesizedMarkdown} className="tk-export-btn" />
         </div>
       )}
       {/* Re-synthesize button */}
@@ -98,7 +72,7 @@ function DistillButton({
       {result && (
         <div className="tk-synth-result">
           <div className="tk-synth-preview">{result}</div>
-          <CopyButton text={result} label="Copy Skill" />
+          <SkillCopyButton text={result} className="tk-export-btn" />
         </div>
       )}
     </>

--- a/src/components/knowledge/__tests__/skillExplorerFilter.test.ts
+++ b/src/components/knowledge/__tests__/skillExplorerFilter.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import type { TopicNode } from '../../../types'
+import {
+  collectFilterOptions,
+  filterTopics,
+  isEmptyCriteria,
+  EMPTY_CRITERIA,
+  type TopicFilterCriteria,
+} from '../skillExplorerFilter'
+
+function node(over: Partial<TopicNode> & { id: string }): TopicNode {
+  return {
+    id: over.id,
+    label: over.label ?? over.id,
+    keywords: over.keywords ?? [],
+    project: over.project ?? (over.projects?.[0] ?? 'p1'),
+    projects: over.projects ?? ['p1'],
+    sessionIds: over.sessionIds ?? ['s1'],
+    sessionCount: 1,
+    totalDurationMinutes: 0,
+    totalToolCalls: 0,
+    firstSeen: over.firstSeen ?? '2026-01-01T00:00:00Z',
+    lastSeen: over.lastSeen ?? '2026-01-01T00:00:00Z',
+    betweennessCentrality: 0,
+    degreeCentrality: 0,
+    communityId: over.communityId ?? 0,
+    representativePrompts: [],
+    suggestedPrompt: '',
+    toolSignature: [],
+    dominantRole: over.dominantRole ?? 'user-driven',
+    reusabilityScore: {
+      overall: over.reusabilityScore?.overall ?? 0.5,
+      frequency: 0,
+      timeCost: 0,
+      crossProjectScore: 0,
+      recency: 0,
+    },
+    facetsSummary: over.facetsSummary,
+  }
+}
+
+const criteria = (over: Partial<TopicFilterCriteria> = {}): TopicFilterCriteria => ({
+  ...EMPTY_CRITERIA,
+  ...over,
+})
+
+describe('collectFilterOptions', () => {
+  it('dedupes and sorts options across topics', () => {
+    const opts = collectFilterOptions([
+      node({ id: 't1', projects: ['b', 'a'], communityId: 2, dominantRole: 'tool-heavy', facetsSummary: { categories: ['feature'], goals: [], successRate: 1, helpfulness: 1 } }),
+      node({ id: 't2', projects: ['a'], communityId: 1, dominantRole: 'user-driven', facetsSummary: { categories: ['bugfix', 'feature'], goals: [], successRate: 1, helpfulness: 1 } }),
+    ])
+    expect(opts.projects).toEqual(['a', 'b'])
+    expect(opts.categories).toEqual(['bugfix', 'feature'])
+    expect(opts.communities).toEqual([1, 2])
+    expect(opts.roles).toEqual(['tool-heavy', 'user-driven'])
+  })
+})
+
+describe('filterTopics', () => {
+  const nodes = [
+    node({ id: 't1', projects: ['crune'], communityId: 0, dominantRole: 'user-driven', keywords: ['embedding', 'retriever'], lastSeen: '2026-06-01T00:00:00Z', reusabilityScore: { overall: 0.8 } as TopicNode['reusabilityScore'], facetsSummary: { categories: ['feature'], goals: [], successRate: 1, helpfulness: 1 } }),
+    node({ id: 't2', projects: ['hatoko'], communityId: 1, dominantRole: 'tool-heavy', keywords: ['auth'], lastSeen: '2026-01-15T00:00:00Z', reusabilityScore: { overall: 0.3 } as TopicNode['reusabilityScore'], facetsSummary: { categories: ['bugfix'], goals: [], successRate: 1, helpfulness: 1 } }),
+  ]
+
+  it('returns all topics for empty criteria', () => {
+    expect(filterTopics(nodes, EMPTY_CRITERIA).map((n) => n.id)).toEqual(['t1', 't2'])
+  })
+
+  it('filters by project (OR)', () => {
+    expect(filterTopics(nodes, criteria({ projects: ['hatoko'] })).map((n) => n.id)).toEqual(['t2'])
+  })
+
+  it('filters by facets category', () => {
+    expect(filterTopics(nodes, criteria({ categories: ['feature'] })).map((n) => n.id)).toEqual(['t1'])
+  })
+
+  it('filters by community and role', () => {
+    expect(filterTopics(nodes, criteria({ communities: [1] })).map((n) => n.id)).toEqual(['t2'])
+    expect(filterTopics(nodes, criteria({ roles: ['user-driven'] })).map((n) => n.id)).toEqual(['t1'])
+  })
+
+  it('filters by keyword over label + keywords (case-insensitive)', () => {
+    expect(filterTopics(nodes, criteria({ keyword: 'RETRIEVER' })).map((n) => n.id)).toEqual(['t1'])
+  })
+
+  it('filters by min reusability', () => {
+    expect(filterTopics(nodes, criteria({ minReusability: 0.5 })).map((n) => n.id)).toEqual(['t1'])
+  })
+
+  it('filters by since (lastSeen lower bound)', () => {
+    expect(filterTopics(nodes, criteria({ since: '2026-03-01T00:00:00Z' })).map((n) => n.id)).toEqual(['t1'])
+  })
+
+  it('filters by min eval score, excluding topics without a score', () => {
+    const evalScores = new Map([['t1', 90]]) // t2 has no eval
+    expect(filterTopics(nodes, criteria({ minEvalScore: 80 }), evalScores).map((n) => n.id)).toEqual(['t1'])
+    expect(filterTopics(nodes, criteria({ minEvalScore: 95 }), evalScores)).toEqual([])
+  })
+
+  it('combines axes with AND', () => {
+    expect(
+      filterTopics(nodes, criteria({ projects: ['crune'], categories: ['bugfix'] })),
+    ).toEqual([])
+  })
+})
+
+describe('isEmptyCriteria', () => {
+  it('is true for the default and false once any axis is set', () => {
+    expect(isEmptyCriteria(EMPTY_CRITERIA)).toBe(true)
+    expect(isEmptyCriteria(criteria({ minReusability: 0.1 }))).toBe(false)
+    expect(isEmptyCriteria(criteria({ projects: ['x'] }))).toBe(false)
+  })
+})

--- a/src/components/knowledge/__tests__/skillExplorerFilter.test.ts
+++ b/src/components/knowledge/__tests__/skillExplorerFilter.test.ts
@@ -3,6 +3,7 @@ import type { TopicNode } from '../../../types'
 import {
   collectFilterOptions,
   filterTopics,
+  sortByReusability,
   isEmptyCriteria,
   EMPTY_CRITERIA,
   type TopicFilterCriteria,
@@ -88,20 +89,46 @@ describe('filterTopics', () => {
     expect(filterTopics(nodes, criteria({ minReusability: 0.5 })).map((n) => n.id)).toEqual(['t1'])
   })
 
-  it('filters by since (lastSeen lower bound)', () => {
-    expect(filterTopics(nodes, criteria({ since: '2026-03-01T00:00:00Z' })).map((n) => n.id)).toEqual(['t1'])
+  it('filters by sinceDays window (relative to injected now)', () => {
+    const now = new Date('2026-06-10T00:00:00Z')
+    // t1 lastSeen 2026-06-01 (9 days ago), t2 2026-01-15 (months ago)
+    expect(filterTopics(nodes, criteria({ sinceDays: 30 }), undefined, now).map((n) => n.id)).toEqual(['t1'])
+    expect(filterTopics(nodes, criteria({ sinceDays: 365 }), undefined, now).map((n) => n.id)).toEqual(['t1', 't2'])
+  })
+
+  it('treats the sinceDays boundary as inclusive', () => {
+    const n = [node({ id: 't', lastSeen: '2026-06-01T00:00:00Z' })]
+    const now = new Date('2026-06-08T00:00:00Z') // exactly 7 days after lastSeen
+    expect(filterTopics(n, criteria({ sinceDays: 7 }), undefined, now).map((x) => x.id)).toEqual(['t'])
+    expect(filterTopics(n, criteria({ sinceDays: 6 }), undefined, now)).toEqual([])
   })
 
   it('filters by min eval score, excluding topics without a score', () => {
     const evalScores = new Map([['t1', 90]]) // t2 has no eval
     expect(filterTopics(nodes, criteria({ minEvalScore: 80 }), evalScores).map((n) => n.id)).toEqual(['t1'])
+    expect(filterTopics(nodes, criteria({ minEvalScore: 90 }), evalScores).map((n) => n.id)).toEqual(['t1']) // equality passes
     expect(filterTopics(nodes, criteria({ minEvalScore: 95 }), evalScores)).toEqual([])
+  })
+
+  it('drops every topic for minEvalScore > 0 when no score map is supplied', () => {
+    expect(filterTopics(nodes, criteria({ minEvalScore: 1 }))).toEqual([])
   })
 
   it('combines axes with AND', () => {
     expect(
       filterTopics(nodes, criteria({ projects: ['crune'], categories: ['bugfix'] })),
     ).toEqual([])
+  })
+})
+
+describe('sortByReusability', () => {
+  it('orders topics by reusability descending without mutating the input', () => {
+    const input = [
+      node({ id: 'lo', reusabilityScore: { overall: 0.2 } as TopicNode['reusabilityScore'] }),
+      node({ id: 'hi', reusabilityScore: { overall: 0.9 } as TopicNode['reusabilityScore'] }),
+    ]
+    expect(sortByReusability(input).map((n) => n.id)).toEqual(['hi', 'lo'])
+    expect(input.map((n) => n.id)).toEqual(['lo', 'hi']) // input untouched
   })
 })
 

--- a/src/components/knowledge/skillExplorerFilter.ts
+++ b/src/components/knowledge/skillExplorerFilter.ts
@@ -15,7 +15,7 @@ export interface TopicFilterCriteria {
   keyword: string // case-insensitive substring over label + keywords
   minReusability: number // 0–1, topic.reusabilityScore.overall >= this
   minEvalScore: number // 0–100, evaluation.overallScore >= this (0 = no constraint)
-  since: string | null // ISO date; topic.lastSeen >= this (null = no constraint)
+  sinceDays: number | null // keep topics active within the last N days (null = no constraint)
 }
 
 export const EMPTY_CRITERIA: TopicFilterCriteria = {
@@ -26,7 +26,14 @@ export const EMPTY_CRITERIA: TopicFilterCriteria = {
   keyword: '',
   minReusability: 0,
   minEvalScore: 0,
-  since: null,
+  sinceDays: null,
+}
+
+/** Role labels (shared by the filter sidebar and the cards). */
+export const ROLE_LABELS: Record<DominantRole, string> = {
+  'user-driven': 'ユーザー主導',
+  'tool-heavy': 'ツール多用',
+  'subagent-delegated': 'サブエージェント委譲',
 }
 
 /** Available filter options derived from the current topic set (for the UI). */
@@ -56,31 +63,38 @@ export function collectFilterOptions(nodes: TopicNode[]): FilterOptions {
   }
 }
 
-function someOverlap<T>(selected: T[], values: T[]): boolean {
+/** True when nothing is selected (no constraint) or some value is selected. */
+function matchesAnySelected<T>(selected: T[], values: T[]): boolean {
   if (selected.length === 0) return true // no constraint
   return values.some((v) => selected.includes(v))
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000
+
 /**
  * Filter topics by the criteria. `evalScores` maps topicId → evaluation
  * overallScore (absent when a topic has no synthesized+evaluated candidate);
- * a topic is dropped by `minEvalScore > 0` when it has no score.
+ * a topic is dropped by `minEvalScore > 0` when it has no score. `now` is
+ * injectable so the `sinceDays` window is deterministic in tests.
  */
 export function filterTopics(
   nodes: TopicNode[],
   criteria: TopicFilterCriteria,
   evalScores?: Map<string, number>,
+  now: Date = new Date(),
 ): TopicNode[] {
   const keyword = criteria.keyword.trim().toLowerCase()
+  const cutoffMs =
+    criteria.sinceDays !== null ? now.getTime() - criteria.sinceDays * DAY_MS : null
   return nodes.filter((n) => {
-    if (!someOverlap(criteria.projects, n.projects ?? [])) return false
-    if (!someOverlap(criteria.categories, n.facetsSummary?.categories ?? [])) return false
-    if (criteria.communities.length > 0 && !criteria.communities.includes(n.communityId)) return false
-    if (!someOverlap(criteria.roles, n.dominantRole ? [n.dominantRole] : [])) return false
-    if ((n.reusabilityScore?.overall ?? 0) < criteria.minReusability) return false
-    if (criteria.since && (n.lastSeen ?? '') < criteria.since) return false
+    if (!matchesAnySelected(criteria.projects, n.projects)) return false
+    if (!matchesAnySelected(criteria.categories, n.facetsSummary?.categories ?? [])) return false
+    if (!matchesAnySelected(criteria.communities, [n.communityId])) return false
+    if (!matchesAnySelected(criteria.roles, [n.dominantRole])) return false
+    if (n.reusabilityScore.overall < criteria.minReusability) return false
+    if (cutoffMs !== null && Date.parse(n.lastSeen) < cutoffMs) return false
     if (keyword) {
-      const hay = `${n.label ?? ''} ${(n.keywords ?? []).join(' ')}`.toLowerCase()
+      const hay = `${n.label} ${n.keywords.join(' ')}`.toLowerCase()
       if (!hay.includes(keyword)) return false
     }
     if (criteria.minEvalScore > 0) {
@@ -89,6 +103,11 @@ export function filterTopics(
     }
     return true
   })
+}
+
+/** Sort topics by reusability (descending) — the explorer's default ranking. */
+export function sortByReusability(nodes: TopicNode[]): TopicNode[] {
+  return [...nodes].sort((a, b) => b.reusabilityScore.overall - a.reusabilityScore.overall)
 }
 
 /** True when the criteria impose no constraint (all topics pass). */
@@ -101,6 +120,6 @@ export function isEmptyCriteria(c: TopicFilterCriteria): boolean {
     c.keyword.trim() === '' &&
     c.minReusability === 0 &&
     c.minEvalScore === 0 &&
-    c.since === null
+    c.sinceDays === null
   )
 }

--- a/src/components/knowledge/skillExplorerFilter.ts
+++ b/src/components/knowledge/skillExplorerFilter.ts
@@ -1,0 +1,106 @@
+import type { TopicNode } from '../../types'
+
+export type DominantRole = TopicNode['dominantRole']
+
+/**
+ * Filter criteria for the skill explorer (issue #73). Empty array / empty string
+ * / zero threshold means "no constraint on that axis", so the default criteria
+ * match every topic.
+ */
+export interface TopicFilterCriteria {
+  projects: string[] // OR within; matches a topic when any of its projects is selected
+  categories: string[] // facets goal categories; OR
+  communities: number[] // Louvain community ids; OR
+  roles: DominantRole[] // dominantRole; OR
+  keyword: string // case-insensitive substring over label + keywords
+  minReusability: number // 0–1, topic.reusabilityScore.overall >= this
+  minEvalScore: number // 0–100, evaluation.overallScore >= this (0 = no constraint)
+  since: string | null // ISO date; topic.lastSeen >= this (null = no constraint)
+}
+
+export const EMPTY_CRITERIA: TopicFilterCriteria = {
+  projects: [],
+  categories: [],
+  communities: [],
+  roles: [],
+  keyword: '',
+  minReusability: 0,
+  minEvalScore: 0,
+  since: null,
+}
+
+/** Available filter options derived from the current topic set (for the UI). */
+export interface FilterOptions {
+  projects: string[]
+  categories: string[]
+  communities: number[]
+  roles: DominantRole[]
+}
+
+export function collectFilterOptions(nodes: TopicNode[]): FilterOptions {
+  const projects = new Set<string>()
+  const categories = new Set<string>()
+  const communities = new Set<number>()
+  const roles = new Set<DominantRole>()
+  for (const n of nodes) {
+    for (const p of n.projects ?? []) projects.add(p)
+    for (const c of n.facetsSummary?.categories ?? []) categories.add(c)
+    if (typeof n.communityId === 'number') communities.add(n.communityId)
+    if (n.dominantRole) roles.add(n.dominantRole)
+  }
+  return {
+    projects: [...projects].sort(),
+    categories: [...categories].sort(),
+    communities: [...communities].sort((a, b) => a - b),
+    roles: [...roles].sort(),
+  }
+}
+
+function someOverlap<T>(selected: T[], values: T[]): boolean {
+  if (selected.length === 0) return true // no constraint
+  return values.some((v) => selected.includes(v))
+}
+
+/**
+ * Filter topics by the criteria. `evalScores` maps topicId → evaluation
+ * overallScore (absent when a topic has no synthesized+evaluated candidate);
+ * a topic is dropped by `minEvalScore > 0` when it has no score.
+ */
+export function filterTopics(
+  nodes: TopicNode[],
+  criteria: TopicFilterCriteria,
+  evalScores?: Map<string, number>,
+): TopicNode[] {
+  const keyword = criteria.keyword.trim().toLowerCase()
+  return nodes.filter((n) => {
+    if (!someOverlap(criteria.projects, n.projects ?? [])) return false
+    if (!someOverlap(criteria.categories, n.facetsSummary?.categories ?? [])) return false
+    if (criteria.communities.length > 0 && !criteria.communities.includes(n.communityId)) return false
+    if (!someOverlap(criteria.roles, n.dominantRole ? [n.dominantRole] : [])) return false
+    if ((n.reusabilityScore?.overall ?? 0) < criteria.minReusability) return false
+    if (criteria.since && (n.lastSeen ?? '') < criteria.since) return false
+    if (keyword) {
+      const hay = `${n.label ?? ''} ${(n.keywords ?? []).join(' ')}`.toLowerCase()
+      if (!hay.includes(keyword)) return false
+    }
+    if (criteria.minEvalScore > 0) {
+      const score = evalScores?.get(n.id)
+      if (score === undefined || score < criteria.minEvalScore) return false
+    }
+    return true
+  })
+}
+
+/** True when the criteria impose no constraint (all topics pass). */
+export function isEmptyCriteria(c: TopicFilterCriteria): boolean {
+  return (
+    c.projects.length === 0 &&
+    c.categories.length === 0 &&
+    c.communities.length === 0 &&
+    c.roles.length === 0 &&
+    c.keyword.trim() === '' &&
+    c.minReusability === 0 &&
+    c.minEvalScore === 0 &&
+    c.since === null
+  )
+}


### PR DESCRIPTION
Implements the MVP of #73: the knowledge ("Rune") tab now defaults to a **faceted skill explorer** instead of the force-directed node-edge graph (which is kept behind a toggle). Filter the corpus along several axes and see the **skill candidates that emerge** from each slice.

## What
- **`skillExplorerFilter.ts`** — pure, tested filter model: `TopicFilterCriteria` (project / facets goal category / community / role / keyword / min reusability / min eval score / time window), `collectFilterOptions`, `filterTopics` (AND across axes, OR within), `sortByReusability`.
- **`SkillExplorerView`** — filter sidebar + results grid; shows `N / M topics` matched.
- **`ExplorerSkillCard`** — per-topic card: reusability %, facets tags, evaluation badge, synthesized-skill preview, on-demand (re)synthesis, related sessions → playback. Reuses `useSkillSynthesis` / `buildGraphContext` / `SkillEvaluationBadge`.
- **`KnowledgeView`** — `Skillエクスプローラ ⇄ グラフ` toggle; `App` renders it for the knowledge tab.

Consumes `TopicNode.facetsSummary` from #75 for the goal-category filter.

## Review (/nirami + /code-review) — fixes, grouped commits
- **Bug:** the time filter stored a derived date, so 直近30日 / 直近90日 both highlighted at once. Criteria now holds `sinceDays`; `filterTopics` derives the cutoff from an injectable `now` and compares with `Date.parse` (no fragile ISO string compare). Inclusive-boundary tests added.
- Extracted a shared **`SkillCopyButton`** (clipboard → file-download fallback, timer cleanup) — dedupes the divergent copy buttons in the explorer and `TacitKnowledgeView`.
- `someOverlap` → `matchesAnySelected` (and route communities through it); dropped defensive `?? []`/`?.` the `TopicNode` type already guarantees; extracted `sortByReusability`; `toggle()` keyed via an `ArrayKeys<T>` type; shared `ROLE_LABELS` so cards and sidebar match.
- Added eval-score equality / no-score-map and sinceDays-window tests.

## Deliberately deferred (noted)
- `SkillExplorerView` render tests (loading/error/empty) — the repo has no jsdom / testing-library env; the pure filter model is fully unit-tested instead.
- Moving the synthesis-request assembly out of the card (info-hiding) and dropping the redundant `evalScores` map — follow-ups; current shape mirrors the existing `DistillButton`.

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `vite build` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ 711/711. Visually verified end-to-end against regenerated data (17 topics, 10 facets categories, 5 synthesized+evaluated candidates) — see the explorer rendering with filters + cards.

Next: PR C — ad-hoc synthesis from a filtered subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)