### PR TITLE
feat(#73): ad-hoc skill synthesis from a filtered slice (Wave 6)

### DIFF
--- a/src/components/knowledge/AdHocSynthesisPanel.css
+++ b/src/components/knowledge/AdHocSynthesisPanel.css
@@ -1,0 +1,64 @@
+.adhoc {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.adhoc-btn {
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.adhoc-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.adhoc-result {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.adhoc-md {
+  margin: 0;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  line-height: 1.5;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.adhoc-error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--danger);
+}
+
+.adhoc-copy,
+.adhoc-close {
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  align-self: flex-start;
+  padding: 3px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}

--- a/src/components/knowledge/AdHocSynthesisPanel.tsx
+++ b/src/components/knowledge/AdHocSynthesisPanel.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import type { TopicNode, EnrichedToolSequence } from '../../types'
+import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
+import { buildAdHocSynthesisRequest } from './adHocSynthesis'
+import { SkillCopyButton } from './SkillCopyButton'
+import './AdHocSynthesisPanel.css'
+
+interface Props {
+  topics: TopicNode[] // the currently filtered topic set
+  enrichedSequences: EnrichedToolSequence[]
+}
+
+/**
+ * Synthesize a single skill from the *whole filtered slice* (issue #73): builds
+ * a synthetic union topic and runs it through the skill-server. Needs the local
+ * skill-server (npm run dev:full).
+ */
+export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis()
+  const [open, setOpen] = useState(false)
+
+  if (topics.length < 2) return null // a single topic already has its own card
+
+  const onSynthesize = () => {
+    const req = buildAdHocSynthesisRequest(topics, enrichedSequences)
+    if (!req) return
+    reset()
+    setOpen(true)
+    synthesize(req)
+  }
+
+  return (
+    <div className="adhoc">
+      <button className="adhoc-btn" onClick={onSynthesize} disabled={loading}>
+        {loading ? '合成中…' : `このフィルタ集合から合成 (${topics.length} topics)`}
+      </button>
+      {open && (result || error) && (
+        <div className="adhoc-result">
+          {error ? (
+            <p className="adhoc-error">{error}</p>
+          ) : (
+            <>
+              <pre className="adhoc-md">{result}</pre>
+              <SkillCopyButton text={result!} className="adhoc-copy" />
+            </>
+          )}
+          <button className="adhoc-close" onClick={() => setOpen(false)}>
+            閉じる
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/knowledge/AdHocSynthesisPanel.tsx
+++ b/src/components/knowledge/AdHocSynthesisPanel.tsx
@@ -22,6 +22,7 @@ export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
   if (topics.length < 2) return null // a single topic already has its own card
 
   const onSynthesize = () => {
+    if (loading) return // don't start a second synthesis while one is in flight
     const req = buildAdHocSynthesisRequest(topics, enrichedSequences)
     if (!req) return
     reset()
@@ -38,12 +39,12 @@ export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
         <div className="adhoc-result">
           {error ? (
             <p className="adhoc-error">{error}</p>
-          ) : (
+          ) : result ? (
             <>
               <pre className="adhoc-md">{result}</pre>
-              <SkillCopyButton text={result!} className="adhoc-copy" />
+              <SkillCopyButton text={result} className="adhoc-copy" />
             </>
-          )}
+          ) : null}
           <button className="adhoc-close" onClick={() => setOpen(false)}>
             閉じる
           </button>

--- a/src/components/knowledge/SkillExplorerView.tsx
+++ b/src/components/knowledge/SkillExplorerView.tsx
@@ -10,6 +10,7 @@ import {
   type TopicFilterCriteria,
 } from './skillExplorerFilter'
 import { ExplorerSkillCard } from './ExplorerSkillCard'
+import { AdHocSynthesisPanel } from './AdHocSynthesisPanel'
 import './SkillExplorerView.css'
 
 interface Props {
@@ -175,6 +176,10 @@ export function SkillExplorerView({ overview, loading, error, onSessionSelect }:
             {filtered.length} / {nodes.length} トピック
           </span>
         </div>
+        <AdHocSynthesisPanel
+          topics={filtered}
+          enrichedSequences={overview?.tacitKnowledge?.enrichedToolSequences ?? []}
+        />
         {filtered.length === 0 ? (
           <div className="fse-state">条件に一致するトピックがありません</div>
         ) : (

--- a/src/components/knowledge/SkillExplorerView.tsx
+++ b/src/components/knowledge/SkillExplorerView.tsx
@@ -177,6 +177,7 @@ export function SkillExplorerView({ overview, loading, error, onSessionSelect }:
           </span>
         </div>
         <AdHocSynthesisPanel
+          key={filtered.map((t) => t.id).join(',')}
           topics={filtered}
           enrichedSequences={overview?.tacitKnowledge?.enrichedToolSequences ?? []}
         />

--- a/src/components/knowledge/__tests__/adHocSynthesis.test.ts
+++ b/src/components/knowledge/__tests__/adHocSynthesis.test.ts
@@ -64,15 +64,27 @@ describe('buildAdHocSynthesisRequest', () => {
     expect(req.skillCandidate.skillMarkdown).toContain('2 topics')
   })
 
-  it('filters enriched sequences by session overlap with the union', () => {
+  it('works for a single topic (the builder allows it; the panel gates ≥2)', () => {
+    const req = buildAdHocSynthesisRequest([node({ id: 't1', sessionIds: ['s1', 's2'] })], [])!
+    expect(req.topicNode.sessionCount).toBe(2)
+    expect(req.skillCandidate.skillMarkdown).toContain('1 topics')
+  })
+
+  it('falls back to a placeholder label when there are no keywords', () => {
+    const req = buildAdHocSynthesisRequest([node({ id: 't1', keywords: [] })], [])!
+    expect(req.topicNode.label).toBe('スライス (1 topics)')
+  })
+
+  it('filters enriched sequences by partial session overlap, dropping empty ones', () => {
     const topics = [node({ id: 't1', sessionIds: ['s1'] })]
     const seqs: EnrichedToolSequence[] = [
-      { sequence: [], count: 1, sessionIds: ['s1'], projects: [] },
-      { sequence: [], count: 1, sessionIds: ['s9'], projects: [] },
+      { sequence: [], count: 1, sessionIds: ['s1', 's9'], projects: [] }, // partial overlap → kept
+      { sequence: [], count: 1, sessionIds: ['s9'], projects: [] }, // no overlap → dropped
+      { sequence: [], count: 1, sessionIds: [], projects: [] }, // empty → dropped
     ]
     const req = buildAdHocSynthesisRequest(topics, seqs)!
     expect(req.enrichedSequences).toHaveLength(1)
-    expect(req.enrichedSequences![0].sessionIds).toEqual(['s1'])
+    expect(req.enrichedSequences![0].sessionIds).toEqual(['s1', 's9'])
   })
 
   it('merges facets when present, omits when none have them', () => {

--- a/src/components/knowledge/__tests__/adHocSynthesis.test.ts
+++ b/src/components/knowledge/__tests__/adHocSynthesis.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import type { TopicNode, EnrichedToolSequence } from '../../../types'
+import { buildAdHocSynthesisRequest, ADHOC_TOPIC_ID } from '../adHocSynthesis'
+
+function node(over: Partial<TopicNode> & { id: string }): TopicNode {
+  return {
+    id: over.id,
+    label: over.label ?? over.id,
+    keywords: over.keywords ?? [],
+    project: over.project ?? (over.projects?.[0] ?? 'p1'),
+    projects: over.projects ?? ['p1'],
+    sessionIds: over.sessionIds ?? ['s1'],
+    sessionCount: over.sessionIds?.length ?? 1,
+    totalDurationMinutes: over.totalDurationMinutes ?? 10,
+    totalToolCalls: over.totalToolCalls ?? 5,
+    firstSeen: over.firstSeen ?? '2026-01-01T00:00:00Z',
+    lastSeen: over.lastSeen ?? '2026-01-01T00:00:00Z',
+    betweennessCentrality: 0,
+    degreeCentrality: 0,
+    communityId: over.communityId ?? 0,
+    representativePrompts: over.representativePrompts ?? [],
+    suggestedPrompt: '',
+    toolSignature: over.toolSignature ?? [],
+    dominantRole: over.dominantRole ?? 'user-driven',
+    reusabilityScore: {
+      overall: over.reusabilityScore?.overall ?? 0.5,
+      frequency: 0,
+      timeCost: 0,
+      crossProjectScore: 0,
+      recency: 0,
+    },
+    facetsSummary: over.facetsSummary,
+  }
+}
+
+describe('buildAdHocSynthesisRequest', () => {
+  it('returns null for an empty selection', () => {
+    expect(buildAdHocSynthesisRequest([], [])).toBeNull()
+  })
+
+  it('builds a synthetic union topic + candidate', () => {
+    const topics = [
+      node({ id: 't1', projects: ['a'], sessionIds: ['s1', 's2'], keywords: ['embed', 'rag'], dominantRole: 'tool-heavy', reusabilityScore: { overall: 0.8 } as TopicNode['reusabilityScore'], toolSignature: [{ tool: 'Bash', weight: 2 }] }),
+      node({ id: 't2', projects: ['b'], sessionIds: ['s2', 's3'], keywords: ['rag'], dominantRole: 'tool-heavy', reusabilityScore: { overall: 0.4 } as TopicNode['reusabilityScore'], toolSignature: [{ tool: 'Bash', weight: 1 }, { tool: 'Edit', weight: 1 }] }),
+    ]
+    const req = buildAdHocSynthesisRequest(topics, [])!
+    expect(req.topicNode.id).toBe(ADHOC_TOPIC_ID)
+    expect(req.skillCandidate.topicId).toBe(ADHOC_TOPIC_ID)
+    // union of sessions, deduped
+    expect([...req.topicNode.sessionIds].sort()).toEqual(['s1', 's2', 's3'])
+    expect(req.topicNode.sessionCount).toBe(3)
+    // union of projects
+    expect([...req.topicNode.projects].sort()).toEqual(['a', 'b'])
+    // 'rag' is most frequent keyword
+    expect(req.topicNode.keywords[0]).toBe('rag')
+    // mode role
+    expect(req.topicNode.dominantRole).toBe('tool-heavy')
+    // averaged reusability
+    expect(req.topicNode.reusabilityScore.overall).toBeCloseTo(0.6)
+    expect(req.skillCandidate.reusabilityScore).toBeCloseTo(0.6)
+    // merged tool signature (Bash summed to 3)
+    expect(req.topicNode.toolSignature[0]).toEqual({ tool: 'Bash', weight: 3 })
+    // heuristic skill markdown references the slice
+    expect(req.skillCandidate.skillMarkdown).toContain('2 topics')
+  })
+
+  it('filters enriched sequences by session overlap with the union', () => {
+    const topics = [node({ id: 't1', sessionIds: ['s1'] })]
+    const seqs: EnrichedToolSequence[] = [
+      { sequence: [], count: 1, sessionIds: ['s1'], projects: [] },
+      { sequence: [], count: 1, sessionIds: ['s9'], projects: [] },
+    ]
+    const req = buildAdHocSynthesisRequest(topics, seqs)!
+    expect(req.enrichedSequences).toHaveLength(1)
+    expect(req.enrichedSequences![0].sessionIds).toEqual(['s1'])
+  })
+
+  it('merges facets when present, omits when none have them', () => {
+    const withFacets = [
+      node({ id: 't1', facetsSummary: { categories: ['feature'], goals: ['ship'], successRate: 1, helpfulness: 0.8 } }),
+      node({ id: 't2', facetsSummary: { categories: ['bugfix'], goals: [], successRate: 0.5, helpfulness: 0.4 } }),
+    ]
+    const merged = buildAdHocSynthesisRequest(withFacets, [])!.topicNode.facetsSummary!
+    expect([...merged.categories].sort()).toEqual(['bugfix', 'feature'])
+    expect(merged.successRate).toBeCloseTo(0.75)
+
+    const noFacets = [node({ id: 't3' })]
+    expect(buildAdHocSynthesisRequest(noFacets, [])!.topicNode.facetsSummary).toBeUndefined()
+  })
+})

--- a/src/components/knowledge/adHocSynthesis.ts
+++ b/src/components/knowledge/adHocSynthesis.ts
@@ -1,0 +1,108 @@
+import type {
+  TopicNode,
+  SkillCandidate,
+  EnrichedToolSequence,
+  SynthesisRequest,
+  ReusabilityScore,
+  TopicFacetsSummary,
+} from '../../types'
+
+export const ADHOC_TOPIC_ID = 'adhoc-slice'
+
+function topByFrequency(values: string[], limit: number): string[] {
+  const count = new Map<string, number>()
+  for (const v of values) count.set(v, (count.get(v) ?? 0) + 1)
+  return [...count.entries()].sort((a, b) => b[1] - a[1]).slice(0, limit).map(([v]) => v)
+}
+
+function mergeFacets(topics: TopicNode[]): TopicFacetsSummary | undefined {
+  const withFacets = topics.filter((t) => t.facetsSummary)
+  if (withFacets.length === 0) return undefined
+  const categories = [...new Set(withFacets.flatMap((t) => t.facetsSummary!.categories))]
+  const goals = [...new Set(withFacets.flatMap((t) => t.facetsSummary!.goals))].slice(0, 3)
+  const avg = (sel: (f: TopicFacetsSummary) => number) =>
+    withFacets.reduce((s, t) => s + sel(t.facetsSummary!), 0) / withFacets.length
+  return { categories, goals, successRate: avg((f) => f.successRate), helpfulness: avg((f) => f.helpfulness) }
+}
+
+/**
+ * Build a synthesis request for the *union* of a filtered topic set (issue #73):
+ * a synthetic TopicNode + SkillCandidate that lets `claude -p` distill one skill
+ * spanning the whole slice. Returns null for an empty selection.
+ */
+export function buildAdHocSynthesisRequest(
+  topics: TopicNode[],
+  enrichedSequences: EnrichedToolSequence[],
+): SynthesisRequest | null {
+  if (topics.length === 0) return null
+
+  const sessionIds = [...new Set(topics.flatMap((t) => t.sessionIds))]
+  const keywords = topByFrequency(topics.flatMap((t) => t.keywords), 8)
+  const projects = [...new Set(topics.flatMap((t) => t.projects))]
+
+  const toolWeight = new Map<string, number>()
+  for (const t of topics) for (const ts of t.toolSignature) toolWeight.set(ts.tool, (toolWeight.get(ts.tool) ?? 0) + ts.weight)
+  const toolSignature = [...toolWeight.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([tool, weight]) => ({ tool, weight }))
+
+  const dominantRole = (topByFrequency(topics.map((t) => t.dominantRole), 1)[0] ??
+    'user-driven') as TopicNode['dominantRole']
+
+  const avg = (sel: (s: ReusabilityScore) => number) =>
+    topics.reduce((sum, t) => sum + sel(t.reusabilityScore), 0) / topics.length
+  const reusabilityScore: ReusabilityScore = {
+    overall: avg((s) => s.overall),
+    frequency: avg((s) => s.frequency),
+    timeCost: avg((s) => s.timeCost),
+    crossProjectScore: avg((s) => s.crossProjectScore),
+    recency: avg((s) => s.recency),
+  }
+
+  const label = `${keywords.slice(0, 3).join(' / ') || 'スライス'} (${topics.length} topics)`
+  const firstSeen = [...topics.map((t) => t.firstSeen)].sort()[0]
+  const lastSeen = [...topics.map((t) => t.lastSeen)].sort().slice(-1)[0]
+
+  const topicNode: TopicNode = {
+    id: ADHOC_TOPIC_ID,
+    label,
+    keywords,
+    project: projects[0] ?? '',
+    projects,
+    sessionIds,
+    sessionCount: sessionIds.length,
+    totalDurationMinutes: topics.reduce((s, t) => s + t.totalDurationMinutes, 0),
+    totalToolCalls: topics.reduce((s, t) => s + t.totalToolCalls, 0),
+    firstSeen,
+    lastSeen,
+    betweennessCentrality: 0,
+    degreeCentrality: 0,
+    communityId: -1,
+    representativePrompts: topics.flatMap((t) => t.representativePrompts).slice(0, 3),
+    suggestedPrompt: '',
+    toolSignature,
+    dominantRole,
+    reusabilityScore,
+    facetsSummary: mergeFacets(topics),
+  }
+
+  const skillMarkdown = [
+    `# ${label}`,
+    '',
+    `Merged from ${topics.length} topics across ${projects.length} project(s).`,
+    `Keywords: ${keywords.join(', ')}`,
+    `Tools: ${toolSignature.map((t) => t.tool).join(', ')}`,
+  ].join('\n')
+
+  const skillCandidate: SkillCandidate = {
+    topicId: ADHOC_TOPIC_ID,
+    reusabilityScore: reusabilityScore.overall,
+    skillMarkdown,
+  }
+
+  const sessionSet = new Set(sessionIds)
+  const related = enrichedSequences.filter((seq) => seq.sessionIds.some((sid) => sessionSet.has(sid)))
+
+  return { skillCandidate, topicNode, enrichedSequences: related }
+}

--- a/src/components/knowledge/adHocSynthesis.ts
+++ b/src/components/knowledge/adHocSynthesis.ts
@@ -79,7 +79,7 @@ export function buildAdHocSynthesisRequest(
     betweennessCentrality: 0,
     degreeCentrality: 0,
     communityId: -1,
-    representativePrompts: topics.flatMap((t) => t.representativePrompts).slice(0, 3),
+    representativePrompts: [...new Set(topics.flatMap((t) => t.representativePrompts))].slice(0, 3),
     suggestedPrompt: '',
     toolSignature,
     dominantRole,


### PR DESCRIPTION
Completes #73. The explorer can now distill **one skill from the whole filtered slice** ("このフィルタ集合から合成"), not just show per-topic candidates — answering "what skill emerges if I slice the corpus *this* way".

## What
- **`adHocSynthesis.ts`** — pure `buildAdHocSynthesisRequest(topics, enrichedSequences)` builds a synthetic union `TopicNode` + `SkillCandidate` (merged sessions / keywords / projects / tool signature, averaged reusability, mode role, merged facets) and the overlapping enriched sequences, then hands it to the existing `/api/synthesize` path. Fully unit-tested.
- **`AdHocSynthesisPanel`** — a button (shown when ≥2 topics are filtered) + result, reusing `useSkillSynthesis` and `SkillCopyButton`; mounted in `SkillExplorerView`.

## Review (/nirami + /code-review) — fixes
- **Bug:** the panel kept its result across filter changes, so after re-filtering it could still show/copy a SKILL.md from the *previous* slice. Now keyed on the filtered topic-id set so it resets when the slice changes (matches the per-topic reset pattern). *(code-review)*
- Early-return in `onSynthesize` while a synthesis is in flight (defense beyond `disabled`); replaced the `result!` assertion with a narrowed render. *(river)*
- Dedupe `representativePrompts` across merged topics; added single-topic / no-keyword-label / partial-and-empty sequence-overlap tests. *(forest / river)*

## Deliberately deferred (noted)
- The synthetic `TopicNode` carries sentinel values (`communityId: -1`, empty `suggestedPrompt`); verified the server's `buildSynthesisPrompt` never dereferences them (graphContext is absent for ad-hoc). A `kind: 'topic' | 'adhoc'` discriminator + a `useSkillSynthesis` result/error → discriminated-union refactor are follow-ups (touch the shared hook + all consumers).
- `firstSeen`/`lastSeen` use ISO string-sort (low severity — unused downstream, consistent with the rest of the pipeline).

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `vite build` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ (6 ad-hoc tests). Visually confirmed the button renders in the explorer.

This closes the #73 MVP (Wave 6): persist facets (#75) → filter explorer (#76) → ad-hoc synthesis (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)