### PR TITLE
feat: keep skill synthesis running in the background (global job store)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,13 +95,15 @@ Synthesis calls use `--no-session-persistence` to prevent creating spurious JSON
 
 ### On-demand re-synthesis
 
-The UI provides a "再合成" button for on-demand re-synthesis with full graph context (connected topics, community, centrality). Synthesis state resets automatically when the selected topic changes. This requires the local skill server:
+The UI provides a "再合成" button for on-demand re-synthesis with full graph context (connected topics, community, centrality). This requires the local skill server:
 
 ```bash
 npm run dev:full    # Runs skill-server + Vite dev server
 ```
 
 The skill server (`scripts/skill-server.ts`) accepts POST requests at `/api/synthesize` and calls `claude -p` with the enriched prompt including graph context.
+
+**Synthesis jobs are global** (`SkillSynthesisProvider`, `src/hooks/`): each `useSkillSynthesis(key)` reads/triggers a job keyed by a stable id (topic id, or an `adhoc:<sorted topic ids>` slice id). The fetch lives in the provider, so a synthesis **keeps running in the background and its result persists** when you change filters, switch tabs, or deselect a node — coming back to the same key shows the running/finished job. (Earlier the state was component-local and was lost on unmount.)
 
 ### Skill Evaluation (issue #20)
 

--- a/src/components/knowledge/AdHocSynthesisPanel.tsx
+++ b/src/components/knowledge/AdHocSynthesisPanel.tsx
@@ -1,6 +1,7 @@
 import type { TopicNode, EnrichedToolSequence } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildAdHocSynthesisRequest } from './adHocSynthesis'
+import { sliceSynthesisKey } from './synthesisKeys'
 import { SkillCopyButton } from './SkillCopyButton'
 import './AdHocSynthesisPanel.css'
 
@@ -17,8 +18,7 @@ interface Props {
  * skill-server (npm run dev:full).
  */
 export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
-  const sliceKey = `adhoc:${topics.map((t) => t.id).sort().join(',')}`
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis(sliceKey)
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis(sliceSynthesisKey(topics))
 
   if (topics.length < 2) return null // a single topic already has its own card
 

--- a/src/components/knowledge/AdHocSynthesisPanel.tsx
+++ b/src/components/knowledge/AdHocSynthesisPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import type { TopicNode, EnrichedToolSequence } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildAdHocSynthesisRequest } from './adHocSynthesis'
@@ -12,22 +11,21 @@ interface Props {
 
 /**
  * Synthesize a single skill from the *whole filtered slice* (issue #73): builds
- * a synthetic union topic and runs it through the skill-server. Needs the local
+ * a synthetic union topic and runs it through the skill-server. The job is keyed
+ * per slice in the SkillSynthesisProvider, so it keeps running in the background
+ * and its result persists when you change filters and come back. Needs the local
  * skill-server (npm run dev:full).
  */
 export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis()
-  const [open, setOpen] = useState(false)
+  const sliceKey = `adhoc:${topics.map((t) => t.id).sort().join(',')}`
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis(sliceKey)
 
   if (topics.length < 2) return null // a single topic already has its own card
 
   const onSynthesize = () => {
-    if (loading) return // don't start a second synthesis while one is in flight
+    if (loading) return // a synthesis for this slice is already in flight
     const req = buildAdHocSynthesisRequest(topics, enrichedSequences)
-    if (!req) return
-    reset()
-    setOpen(true)
-    synthesize(req)
+    if (req) synthesize(req)
   }
 
   return (
@@ -35,7 +33,7 @@ export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
       <button className="adhoc-btn" onClick={onSynthesize} disabled={loading}>
         {loading ? '合成中…' : `このフィルタ集合から合成 (${topics.length} topics)`}
       </button>
-      {open && (result || error) && (
+      {(result || error) && (
         <div className="adhoc-result">
           {error ? (
             <p className="adhoc-error">{error}</p>
@@ -45,7 +43,7 @@ export function AdHocSynthesisPanel({ topics, enrichedSequences }: Props) {
               <SkillCopyButton text={result} className="adhoc-copy" />
             </>
           ) : null}
-          <button className="adhoc-close" onClick={() => setOpen(false)}>
+          <button className="adhoc-close" onClick={reset}>
             閉じる
           </button>
         </div>

--- a/src/components/knowledge/ExplorerSkillCard.tsx
+++ b/src/components/knowledge/ExplorerSkillCard.tsx
@@ -11,6 +11,7 @@ import { buildGraphContext } from '../../utils/buildGraphContext'
 import { SkillEvaluationBadge } from './SkillEvaluationBadge'
 import { SkillCopyButton } from './SkillCopyButton'
 import { ROLE_LABELS } from './skillExplorerFilter'
+import { topicSynthesisKey } from './synthesisKeys'
 import './ExplorerSkillCard.css'
 
 interface Props {
@@ -34,7 +35,7 @@ export function ExplorerSkillCard({
   bridgeTopicIds,
   onSessionSelect,
 }: Props) {
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis(topic.id)
+  const { synthesize, loading, result, error } = useSkillSynthesis(topicSynthesisKey(topic.id))
   const [expanded, setExpanded] = useState(false)
 
   const score = Math.round((topic.reusabilityScore?.overall ?? 0) * 100)
@@ -42,7 +43,6 @@ export function ExplorerSkillCard({
 
   const onSynthesize = useCallback(() => {
     if (!candidate) return
-    reset()
     const relatedSequences = enrichedSequences.filter((seq) =>
       seq.sessionIds.some((sid) => topic.sessionIds.includes(sid)),
     )
@@ -53,7 +53,7 @@ export function ExplorerSkillCard({
       enrichedSequences: relatedSequences,
       graphContext: buildGraphContext(topic, topicEdges, allTopics, communities, bridgeTopicIds),
     })
-  }, [candidate, enrichedSequences, edges, topic, allTopics, communities, bridgeTopicIds, synthesize, reset])
+  }, [candidate, enrichedSequences, edges, topic, allTopics, communities, bridgeTopicIds, synthesize])
 
   return (
     <article className="fse-card">

--- a/src/components/knowledge/ExplorerSkillCard.tsx
+++ b/src/components/knowledge/ExplorerSkillCard.tsx
@@ -34,7 +34,7 @@ export function ExplorerSkillCard({
   bridgeTopicIds,
   onSessionSelect,
 }: Props) {
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis()
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis(topic.id)
   const [expanded, setExpanded] = useState(false)
 
   const score = Math.round((topic.reusabilityScore?.overall ?? 0) * 100)

--- a/src/components/knowledge/KnowledgeNodeDetail.tsx
+++ b/src/components/knowledge/KnowledgeNodeDetail.tsx
@@ -3,6 +3,7 @@ import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedTo
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import { SkillEvaluationBadge } from './SkillEvaluationBadge'
+import { topicSynthesisKey, NO_TOPIC_KEY } from './synthesisKeys'
 import './KnowledgeNodeDetail.css'
 
 interface Props {
@@ -77,7 +78,9 @@ export function KnowledgeNodeDetail({
   const [synthCopied, setSynthCopied] = useState(false)
   // Keyed by node id so the synthesis job persists in the provider when the
   // selection changes and back (#73 follow-up: keep results across navigation).
-  const { synthesize, loading: synthLoading, result: synthResult, error: synthError, reset: resetSynth } = useSkillSynthesis(node?.id ?? '__none__')
+  const { synthesize, loading: synthLoading, result: synthResult, error: synthError } = useSkillSynthesis(
+    node ? topicSynthesisKey(node.id) : NO_TOPIC_KEY,
+  )
 
   const skillCandidate = useMemo(() => {
     if (!node || !skillCandidates) return null
@@ -211,7 +214,6 @@ export function KnowledgeNodeDetail({
               className="knd-synth-btn"
               disabled={synthLoading}
               onClick={() => {
-                resetSynth()
                 synthesize({
                   skillCandidate,
                   topicNode: node,

--- a/src/components/knowledge/KnowledgeNodeDetail.tsx
+++ b/src/components/knowledge/KnowledgeNodeDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { TopicNode, TopicEdge, SemanticEdgeType, SkillCandidate, EnrichedToolSequence, KnowledgeCommunity } from '../../types'
 import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
@@ -75,11 +75,9 @@ export function KnowledgeNodeDetail({
   onClose,
 }: Props) {
   const [synthCopied, setSynthCopied] = useState(false)
-  const { synthesize, loading: synthLoading, result: synthResult, error: synthError, reset: resetSynth } = useSkillSynthesis()
-
-  useEffect(() => {
-    resetSynth()
-  }, [node?.id, resetSynth])
+  // Keyed by node id so the synthesis job persists in the provider when the
+  // selection changes and back (#73 follow-up: keep results across navigation).
+  const { synthesize, loading: synthLoading, result: synthResult, error: synthError, reset: resetSynth } = useSkillSynthesis(node?.id ?? '__none__')
 
   const skillCandidate = useMemo(() => {
     if (!node || !skillCandidates) return null

--- a/src/components/knowledge/SkillExplorerView.tsx
+++ b/src/components/knowledge/SkillExplorerView.tsx
@@ -177,7 +177,6 @@ export function SkillExplorerView({ overview, loading, error, onSessionSelect }:
           </span>
         </div>
         <AdHocSynthesisPanel
-          key={filtered.map((t) => t.id).join(',')}
           topics={filtered}
           enrichedSequences={overview?.tacitKnowledge?.enrichedToolSequences ?? []}
         />

--- a/src/components/knowledge/TacitKnowledgeView.tsx
+++ b/src/components/knowledge/TacitKnowledgeView.tsx
@@ -30,7 +30,7 @@ function DistillButton({
   communities?: KnowledgeCommunity[]
   bridgeTopicIds?: string[]
 }) {
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis()
+  const { synthesize, loading, result, error, reset } = useSkillSynthesis(candidate.topicId)
 
   if (!topic) return null
 

--- a/src/components/knowledge/TacitKnowledgeView.tsx
+++ b/src/components/knowledge/TacitKnowledgeView.tsx
@@ -3,6 +3,7 @@ import { useSkillSynthesis } from '../../hooks/useSkillSynthesis'
 import { buildGraphContext } from '../../utils/buildGraphContext'
 import { SkillEvaluationBadge } from './SkillEvaluationBadge'
 import { SkillCopyButton } from './SkillCopyButton'
+import { topicSynthesisKey } from './synthesisKeys'
 import './TacitKnowledgeView.css'
 
 interface Props {
@@ -30,7 +31,7 @@ function DistillButton({
   communities?: KnowledgeCommunity[]
   bridgeTopicIds?: string[]
 }) {
-  const { synthesize, loading, result, error, reset } = useSkillSynthesis(candidate.topicId)
+  const { synthesize, loading, result, error } = useSkillSynthesis(topicSynthesisKey(candidate.topicId))
 
   if (!topic) return null
 
@@ -57,7 +58,6 @@ function DistillButton({
         className="tk-synth-btn"
         disabled={loading}
         onClick={() => {
-          reset()
           synthesize({
             skillCandidate: candidate,
             topicNode: topic,

--- a/src/components/knowledge/synthesisKeys.ts
+++ b/src/components/knowledge/synthesisKeys.ts
@@ -1,0 +1,15 @@
+import type { TopicNode } from '../../types'
+
+/**
+ * Stable keys for synthesis jobs in the SkillSynthesisProvider. Namespaced by
+ * kind so a topic job and an ad-hoc slice job can never collide, and so the
+ * key scheme lives in one place.
+ */
+export const topicSynthesisKey = (topicId: string): string => `topic:${topicId}`
+
+/** Key for the union of a filtered topic set — order-independent. */
+export const sliceSynthesisKey = (topics: TopicNode[]): string =>
+  `adhoc:${topics.map((t) => t.id).sort().join(',')}`
+
+/** Placeholder key when no topic is selected (never a real topic id). */
+export const NO_TOPIC_KEY = 'topic:__none__'

--- a/src/hooks/SkillSynthesisProvider.tsx
+++ b/src/hooks/SkillSynthesisProvider.tsx
@@ -1,0 +1,34 @@
+import { useCallback, useState, type ReactNode } from 'react'
+import type { SynthesisRequest } from '../types'
+import { SkillSynthesisContext, runSynthesis, type SynthesisJob } from './skillSynthesisContext'
+
+/**
+ * Holds skill-synthesis jobs keyed by a caller-chosen id (topic id, ad-hoc
+ * slice id, …) so a synthesis keeps running in the background and its result
+ * persists across filter changes / navigation / unmounts (issue #73 follow-up).
+ */
+export function SkillSynthesisProvider({ children }: { children: ReactNode }) {
+  const [jobs, setJobs] = useState<Record<string, SynthesisJob>>({})
+
+  const reset = useCallback((key: string) => {
+    setJobs((prev) => {
+      if (!(key in prev)) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }, [])
+
+  const synthesize = useCallback((key: string, req: SynthesisRequest) => {
+    setJobs((prev) => ({ ...prev, [key]: { status: 'loading' } }))
+    void runSynthesis(req).then((job) => {
+      setJobs((prev) => ({ ...prev, [key]: job }))
+    })
+  }, [])
+
+  return (
+    <SkillSynthesisContext.Provider value={{ jobs, synthesize, reset }}>
+      {children}
+    </SkillSynthesisContext.Provider>
+  )
+}

--- a/src/hooks/SkillSynthesisProvider.tsx
+++ b/src/hooks/SkillSynthesisProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from 'react'
+import { useCallback, useRef, useState, type ReactNode } from 'react'
 import type { SynthesisRequest } from '../types'
 import { SkillSynthesisContext, runSynthesis, type SynthesisJob } from './skillSynthesisContext'
 
@@ -9,8 +9,14 @@ import { SkillSynthesisContext, runSynthesis, type SynthesisJob } from './skillS
  */
 export function SkillSynthesisProvider({ children }: { children: ReactNode }) {
   const [jobs, setJobs] = useState<Record<string, SynthesisJob>>({})
+  // Per-key generation counter: every synthesize/reset bumps it, and an
+  // in-flight resolution only writes if its generation is still current. This
+  // prevents a dismissed (reset) job from being resurrected by a late fetch and
+  // a slow earlier re-synthesis from overwriting a faster later one.
+  const gen = useRef<Record<string, number>>({})
 
   const reset = useCallback((key: string) => {
+    gen.current[key] = (gen.current[key] ?? 0) + 1 // invalidate any in-flight job
     setJobs((prev) => {
       if (!(key in prev)) return prev
       const next = { ...prev }
@@ -20,8 +26,10 @@ export function SkillSynthesisProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const synthesize = useCallback((key: string, req: SynthesisRequest) => {
+    const generation = (gen.current[key] = (gen.current[key] ?? 0) + 1)
     setJobs((prev) => ({ ...prev, [key]: { status: 'loading' } }))
     void runSynthesis(req).then((job) => {
+      if (gen.current[key] !== generation) return // superseded by a reset or newer call
       setJobs((prev) => ({ ...prev, [key]: job }))
     })
   }, [])

--- a/src/hooks/__tests__/skillSynthesisContext.test.ts
+++ b/src/hooks/__tests__/skillSynthesisContext.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { runSynthesis } from '../skillSynthesisContext'
+import type { SynthesisRequest } from '../../types'
+
+const req = {} as SynthesisRequest
+
+function mockFetch(impl: () => Partial<Response> | Promise<Partial<Response>>) {
+  vi.stubGlobal('fetch', vi.fn(async () => impl() as unknown as Response))
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('runSynthesis', () => {
+  it('maps a successful response to a success job', async () => {
+    mockFetch(() => ({ ok: true, json: async () => ({ success: true, synthesizedMarkdown: '# Skill' }) }))
+    expect(await runSynthesis(req)).toEqual({ status: 'success', markdown: '# Skill' })
+  })
+
+  it('maps a non-ok HTTP response to an error job with the status', async () => {
+    mockFetch(() => ({ ok: false, status: 503, text: async () => 'unavailable' }))
+    const job = await runSynthesis(req)
+    expect(job.status).toBe('error')
+    expect(job.error).toContain('503')
+  })
+
+  it('maps a success:false body to its error message', async () => {
+    mockFetch(() => ({ ok: true, json: async () => ({ success: false, error: 'bad prompt' }) }))
+    expect(await runSynthesis(req)).toEqual({ status: 'error', error: 'bad prompt' })
+  })
+
+  it('reports a friendly message when the server is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch') }))
+    const job = await runSynthesis(req)
+    expect(job.status).toBe('error')
+    expect(job.error).toMatch(/skill server is not running/i)
+  })
+})

--- a/src/hooks/__tests__/skillSynthesisContext.test.ts
+++ b/src/hooks/__tests__/skillSynthesisContext.test.ts
@@ -28,8 +28,14 @@ describe('runSynthesis', () => {
     expect(await runSynthesis(req)).toEqual({ status: 'error', error: 'bad prompt' })
   })
 
-  it('reports a friendly message when the server is unreachable', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch') }))
+  it('reports an empty-result error when success has no markdown', async () => {
+    mockFetch(() => ({ ok: true, json: async () => ({ success: true }) }))
+    expect(await runSynthesis(req)).toEqual({ status: 'error', error: 'Empty synthesis result' })
+  })
+
+  it('reports a friendly message for any connection TypeError (browser-independent)', async () => {
+    // Safari throws "Load failed" (no "fetch" substring) — must still be caught.
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Load failed') }))
     const job = await runSynthesis(req)
     expect(job.status).toBe('error')
     expect(job.error).toMatch(/skill server is not running/i)

--- a/src/hooks/skillSynthesisContext.ts
+++ b/src/hooks/skillSynthesisContext.ts
@@ -20,12 +20,17 @@ export async function runSynthesis(req: SynthesisRequest): Promise<SynthesisJob>
       return { status: 'error', error: `Server error (${res.status}): ${text}` }
     }
     const data: SynthesisResponse = await res.json()
-    if (data.success && data.synthesizedMarkdown) {
-      return { status: 'success', markdown: data.synthesizedMarkdown }
+    if (data.success) {
+      return data.synthesizedMarkdown
+        ? { status: 'success', markdown: data.synthesizedMarkdown }
+        : { status: 'error', error: 'Empty synthesis result' }
     }
     return { status: 'error', error: data.error ?? 'Unknown error' }
   } catch (e) {
-    if (e instanceof TypeError && e.message.includes('fetch')) {
+    // fetch() rejects with a TypeError on a connection failure (the server not
+    // running); a bad JSON body rejects with SyntaxError, handled separately.
+    // Don't match on the message text — it differs across browsers.
+    if (e instanceof TypeError) {
       return { status: 'error', error: 'Skill server is not running. Start it with: npm run skill-server' }
     }
     return { status: 'error', error: e instanceof Error ? e.message : 'Unknown error' }

--- a/src/hooks/skillSynthesisContext.ts
+++ b/src/hooks/skillSynthesisContext.ts
@@ -1,0 +1,43 @@
+import { createContext } from 'react'
+import type { SynthesisRequest, SynthesisResponse } from '../types'
+
+export interface SynthesisJob {
+  status: 'loading' | 'success' | 'error'
+  markdown?: string
+  error?: string
+}
+
+/** Run one synthesis and map the response/failure to a terminal job state. */
+export async function runSynthesis(req: SynthesisRequest): Promise<SynthesisJob> {
+  try {
+    const res = await fetch('/api/synthesize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      return { status: 'error', error: `Server error (${res.status}): ${text}` }
+    }
+    const data: SynthesisResponse = await res.json()
+    if (data.success && data.synthesizedMarkdown) {
+      return { status: 'success', markdown: data.synthesizedMarkdown }
+    }
+    return { status: 'error', error: data.error ?? 'Unknown error' }
+  } catch (e) {
+    if (e instanceof TypeError && e.message.includes('fetch')) {
+      return { status: 'error', error: 'Skill server is not running. Start it with: npm run skill-server' }
+    }
+    return { status: 'error', error: e instanceof Error ? e.message : 'Unknown error' }
+  }
+}
+
+export interface SkillSynthesisContextValue {
+  jobs: Record<string, SynthesisJob>
+  /** Start (or restart) a synthesis tracked under `key`. Fire-and-forget: the
+   *  fetch lives in the provider, so it survives the caller unmounting. */
+  synthesize: (key: string, req: SynthesisRequest) => void
+  reset: (key: string) => void
+}
+
+export const SkillSynthesisContext = createContext<SkillSynthesisContextValue | null>(null)

--- a/src/hooks/useSkillSynthesis.ts
+++ b/src/hooks/useSkillSynthesis.ts
@@ -1,58 +1,40 @@
-import { useState, useCallback } from 'react'
-import type { SynthesisRequest, SynthesisResponse } from '../types'
+import { useCallback, useContext } from 'react'
+import { SkillSynthesisContext } from './skillSynthesisContext'
+import type { SynthesisRequest } from '../types'
 
 interface UseSkillSynthesisResult {
-  synthesize: (req: SynthesisRequest) => Promise<void>
+  synthesize: (req: SynthesisRequest) => void
   loading: boolean
   result: string | null
   error: string | null
   reset: () => void
 }
 
-export function useSkillSynthesis(): UseSkillSynthesisResult {
-  const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
+/**
+ * Read/trigger the synthesis job tracked under `key` (a stable id for the thing
+ * being synthesized — a topic id or an ad-hoc slice id). State lives in the
+ * SkillSynthesisProvider, so the job keeps running and its result persists even
+ * if this component unmounts (filter change, tab switch, …).
+ */
+export function useSkillSynthesis(key: string): UseSkillSynthesisResult {
+  const ctx = useContext(SkillSynthesisContext)
+  if (!ctx) {
+    throw new Error('useSkillSynthesis must be used within a SkillSynthesisProvider')
+  }
+  const job = ctx.jobs[key]
 
-  const reset = useCallback(() => {
-    setResult(null)
-    setError(null)
-  }, [])
+  const { synthesize: ctxSynthesize, reset: ctxReset } = ctx
+  const synthesize = useCallback(
+    (req: SynthesisRequest) => ctxSynthesize(key, req),
+    [ctxSynthesize, key],
+  )
+  const reset = useCallback(() => ctxReset(key), [ctxReset, key])
 
-  const synthesize = useCallback(async (req: SynthesisRequest) => {
-    setLoading(true)
-    setResult(null)
-    setError(null)
-
-    try {
-      const res = await fetch('/api/synthesize', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(req),
-      })
-
-      if (!res.ok) {
-        const text = await res.text()
-        setError(`Server error (${res.status}): ${text}`)
-        return
-      }
-
-      const data: SynthesisResponse = await res.json()
-      if (data.success && data.synthesizedMarkdown) {
-        setResult(data.synthesizedMarkdown)
-      } else {
-        setError(data.error ?? 'Unknown error')
-      }
-    } catch (e) {
-      if (e instanceof TypeError && e.message.includes('fetch')) {
-        setError('Skill server is not running. Start it with: npm run skill-server')
-      } else {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      }
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  return { synthesize, loading, result, error, reset }
+  return {
+    synthesize,
+    loading: job?.status === 'loading',
+    result: job?.status === 'success' ? job.markdown ?? null : null,
+    error: job?.status === 'error' ? job.error ?? null : null,
+    reset,
+  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { Chart, registerables } from 'chart.js'
 import './index.css'
 import App from './App.tsx'
+import { SkillSynthesisProvider } from './hooks/SkillSynthesisProvider'
 
 Chart.register(...registerables)
 Chart.defaults.color = '#78716c'
@@ -10,6 +11,8 @@ Chart.defaults.borderColor = '#e7e5e4'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SkillSynthesisProvider>
+      <App />
+    </SkillSynthesisProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
Fixes the UX problem raised on #73: triggering a skill synthesis and then changing a filter / switching tabs / deselecting a node **lost the in-flight request and the result**, because every synthesis button held its state component-locally (`useSkillSynthesis`) and was unmounted.

## What
- **`SkillSynthesisProvider`** (global context) holds synthesis jobs keyed by a stable id. The fetch lives in the provider, so a synthesis **keeps running in the background and its result persists** — come back to the same key and the running/finished job is still there.
- `useSkillSynthesis(key)` keeps the same return shape; call sites just pass a key (`synthesisKeys.ts`: `topic:<id>` / `adhoc:<sorted ids>`).
- Removed the per-node "reset on change" effect and the ad-hoc remount `key` hack that previously discarded results.

## Review (/nirami + /code-review) — fixes
- **Race (critical):** a per-key **generation guard** so an in-flight fetch only writes if it's still current — fixes (a) `reset()` (the ad-hoc 閉じる) resurrecting a dismissed result when the fetch later resolves, and (b) a slow earlier re-synthesis overwriting a faster later one. *(stone / river / code-review)*
- Dropped the redundant `reset()` that ran right before `synthesize()` (no-op that only widened the race). *(stone / river)*
- `runSynthesis` is now browser-independent (any connection `TypeError` → "server not running"; Safari's message lacks "fetch") and returns an explicit `Empty synthesis result`. *(river)*
- Centralized job keys in `synthesisKeys.ts` (removes the `__none__` sentinel collision risk + inline slice key). *(stone)*
- Tests: `runSynthesis` mapping incl. empty-markdown + any-TypeError.

## Deliberately deferred (noted)
- `jobs` grows for the session (no LRU eviction) — bounded by user actions, cleared on reload; an LRU is a follow-up.
- A shared `<SynthesisResult>` component (result/copy rendering is duplicated across the 4 surfaces; `KnowledgeNodeDetail` still hand-rolls clipboard) — pre-existing; worth a follow-up.
- A provider-level race regression test needs `renderHook` — the repo has no jsdom/testing-library env; the generation guard's `runSynthesis` half is unit-tested and the race is reasoned through.

## Verification
`tsc -b` ✅ · `build:cli` ✅ · `vite build` ✅ · `eslint` ✅ (0 errors) · `vitest` ✅ 722/722. App boots with the provider (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)